### PR TITLE
Fix simulator script path

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
       }
     }
 </script>
-<script type="module" src="/hbds_class.js"></script>
+<script type="module" src="hbds_class.js"></script>
 
 </body>
 </html>

--- a/openbexi_hbds.html
+++ b/openbexi_hbds.html
@@ -58,7 +58,7 @@
       }
     }
 </script>
-<script type="module" src="/hbds_class.js"></script>
+<script type="module" src="hbds_class.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- use a relative path for `hbds_class.js` in both HTML entrypoints

## Testing
- `mvn -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6861b707b2a08331a954c64e52b772f4