### PR TITLE
Add dedicated class-link module with curved multi-link rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
             <option value="human_and_car">human_and_car</option>
             <option value="human_and_car_and_more">human_and_car_and_more</option>
             <option value="transportation">transportation</option>
+            <option value="human_and_car_links">human_and_car_links</option>
         </select>
     </div>
     <div class="control-group">
@@ -40,7 +41,9 @@
     import {OrbitControls} from 'three/addons/controls/OrbitControls.js';
     import {DragControls} from 'three/addons/controls/DragControls.js';
     import {CSS2DRenderer} from 'three/addons/renderers/CSS2DRenderer.js';
-    import {Loader, createClass, updateLabelFontSizes} from './js/hbds_class.js';
+    import {Loader as ClassLoader, createClass, updateLabelFontSizes} from './js/hbds_class.js';
+    import { Loader, createLinkBetweenClass, updateLinkFontSizes } from './js/hbds_class_link.js';
+    import { recalculateAllLinks } from './js/hbds_class_link.js';
 
     /* ---------- Globals ---------- */
     let scene, camera, renderer, css2DRenderer, orbitControls, dragControls;
@@ -97,15 +100,22 @@
         }
         if (dragControls) dragControls.dispose();
 
-        const data = await Loader.load(modelName);
+        const data = await ClassLoader.load(modelName);
         diagramGroup = new THREE.Group();
         scene.add(diagramGroup);
 
+        const classById = new Map();
         data.hypergraph.class.forEach(cd => {
             const {classMesh} = createClass(cd);
             classMesh.position.set(cd.position.x, cd.position.y, cd.position.z);
             diagramGroup.add(classMesh);
             draggableObjects.push(classMesh);  // only the rectangle is the handle
+            classById.set(cd.id, classMesh);
+        });
+
+        (data.hypergraph.link || []).forEach(ld => {
+            const link = createLinkBetweenClass(ld, classById);
+            if (link) diagramGroup.add(link.linkGroup);
         });
 
         // Center diagram
@@ -118,11 +128,15 @@
         setupDragControls();
         //updateLabelFontSizes(camera);
         orbitControls.addEventListener('change', () => {
-            updateLabelFontSizes(camera);   // <-- your distance-based font fix
+            updateLabelFontSizes(camera);
+            updateLinkFontSizes(camera);
+            recalculateAllLinks();
             renderer.render(scene, camera);
             css2DRenderer.render(scene, camera);
         });
-        updateLabelFontSizes(camera);   // <-- your distance-based font fix
+        updateLabelFontSizes(camera);
+        updateLinkFontSizes(camera);
+        recalculateAllLinks();
         renderer.render(scene, camera);
         css2DRenderer.render(scene, camera);
     }
@@ -135,7 +149,8 @@
             orbitControls.enabled = false;
         });
 
-        dragControls.addEventListener('drag', ev => {
+        dragControls.addEventListener('drag', () => {
+            recalculateAllLinks();
         });
 
         dragControls.addEventListener('dragend', () => {
@@ -151,7 +166,9 @@
         camera.aspect = window.innerWidth / window.innerHeight;
         renderer.setSize(window.innerWidth, window.innerHeight);
         css2DRenderer.setSize(window.innerWidth, window.innerHeight);
-        updateLabelFontSizes(camera);   // <-- your distance-based font fix
+        updateLabelFontSizes(camera);
+        updateLinkFontSizes(camera);
+        recalculateAllLinks();
         renderer.render(scene, camera);
         css2DRenderer.render(scene, camera);
         camera.updateProjectionMatrix();

--- a/js/hbds_class.js
+++ b/js/hbds_class.js
@@ -79,6 +79,7 @@ export function createClass(classData) {
     });
     const classMesh = new THREE.Mesh(extrudeGeom, classMat);
     classMesh.position.z = Z_BASE;
+    classMesh.userData.classId = classData.id;
 
     /* — Class name label (CSS2D) — */
     const titleDiv = document.createElement('div');
@@ -99,6 +100,7 @@ export function createClass(classData) {
         new THREE.CircleGeometry(0.04, 32),
         new THREE.MeshBasicMaterial({color: '#FF0000'})
     );
+    hub.name = 'class-hub';
     hub.position.copy(hubPos);
     hub.raycast = () => {
     };

--- a/js/hbds_class_link.js
+++ b/js/hbds_class_link.js
@@ -1,0 +1,137 @@
+import * as THREE from 'three';
+import { CSS2DObject } from 'three/addons/renderers/CSS2DRenderer.js';
+
+const linkLabels = [];
+const activeLinks = [];
+
+export const Loader = {
+  async load(modelName) {
+    const res = await fetch(`./models/${modelName}.json`);
+    if (!res.ok) throw new Error(`Model not found: ${modelName}`);
+    return await res.json();
+  }
+};
+
+function getHubWorldPosition(classMesh) {
+  const hub = classMesh.getObjectByName('class-hub');
+  if (!hub) return classMesh.getWorldPosition(new THREE.Vector3());
+  return hub.getWorldPosition(new THREE.Vector3());
+}
+
+function pathPoint(p0, p1, c, t) {
+  const mt = 1 - t;
+  return new THREE.Vector3()
+    .copy(p0).multiplyScalar(mt * mt)
+    .add(new THREE.Vector3().copy(c).multiplyScalar(2 * mt * t))
+    .add(new THREE.Vector3().copy(p1).multiplyScalar(t * t));
+}
+
+export function createLinkBetweenClass(linkData, classById) {
+  const sourceClass = classById.get(linkData.sourceClassId);
+  const targetClass = classById.get(linkData.targetClassId);
+  if (!sourceClass || !targetClass) return null;
+
+  const rendering = linkData.rendering ?? {};
+  const lineStyle = rendering.lineStyle ?? 'solid';
+  const mat = new THREE.LineBasicMaterial({
+    color: rendering.lineColor ?? '#333333',
+    linewidth: rendering.lineWidth ?? 2
+  });
+  if (lineStyle === 'dashed' || lineStyle === 'dotted') {
+    mat.dashSize = lineStyle === 'dotted' ? 0.04 : 0.15;
+    mat.gapSize = lineStyle === 'dotted' ? 0.08 : 0.1;
+  }
+
+  const geometry = new THREE.BufferGeometry();
+  const line = new THREE.Line(geometry, mat);
+  if (lineStyle !== 'solid') line.computeLineDistances();
+  line.renderOrder = rendering.zIndex ?? 5;
+
+  const arrow = new THREE.Mesh(
+    new THREE.ConeGeometry((rendering.arrowheadSize ?? 0.1) * 0.45, rendering.arrowheadSize ?? 0.1, 12),
+    new THREE.MeshBasicMaterial({ color: rendering.lineColor ?? '#333333' })
+  );
+  arrow.visible = rendering.arrowheadVisibility !== false;
+  arrow.renderOrder = (rendering.zIndex ?? 5) + 1;
+
+  const labelDiv = document.createElement('div');
+  labelDiv.className = 'label link-label';
+  labelDiv.textContent = rendering.labelText ?? '';
+  labelDiv.style.font = `${rendering.labelFontSize ?? 12}px Arial`;
+  labelDiv.style.color = rendering.labelColor ?? '#111111';
+  labelDiv.style.background = rendering.labelBackgroundColor ?? 'rgba(255,255,255,0.9)';
+  labelDiv.style.padding = '1px 4px';
+  labelDiv.style.borderRadius = '3px';
+  const labelObj = new CSS2DObject(labelDiv);
+  linkLabels.push(labelObj);
+
+  const linkGroup = new THREE.Group();
+  linkGroup.add(line, arrow, labelObj);
+
+  const handle = { linkData, sourceClass, targetClass, line, arrow, labelObj, linkGroup };
+  activeLinks.push(handle);
+  recalculateAllLinks();
+  return handle;
+}
+
+export function recalculateAllLinks() {
+  const pairBuckets = new Map();
+  for (const l of activeLinks) {
+    const k = [l.linkData.sourceClassId, l.linkData.targetClassId].sort((a,b)=>a-b).join(':');
+    if (!pairBuckets.has(k)) pairBuckets.set(k, []);
+    pairBuckets.get(k).push(l);
+  }
+
+  for (const bucket of pairBuckets.values()) {
+    const count = bucket.length;
+    bucket.forEach((l, idx) => {
+      const p0 = getHubWorldPosition(l.sourceClass);
+      const p1 = getHubWorldPosition(l.targetClass);
+      const mid = new THREE.Vector3().addVectors(p0, p1).multiplyScalar(0.5);
+      const dir = new THREE.Vector3().subVectors(p1, p0);
+      const n = new THREE.Vector3(-dir.y, dir.x, 0).normalize();
+
+      const spacing = l.linkData.rendering?.curveOffset ?? 0.35;
+      const offsetIndex = idx - (count - 1) / 2;
+      const bidirectional = l.linkData.sourceClassId > l.linkData.targetClassId ? -1 : 1;
+      const control = mid.clone().addScaledVector(n, spacing * offsetIndex * bidirectional);
+
+      const points = [];
+      const seg = 40;
+      for (let i = 0; i <= seg; i++) points.push(pathPoint(p0, p1, control, i / seg));
+      l.line.geometry.setFromPoints(points);
+      l.line.computeLineDistances();
+
+      const arrowT = 0.93;
+      const arrowPos = pathPoint(p0, p1, control, arrowT);
+      const prev = pathPoint(p0, p1, control, arrowT - 0.03);
+      l.arrow.position.copy(arrowPos);
+      l.arrow.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), arrowPos.clone().sub(prev).normalize());
+
+      const labelT = l.linkData.rendering?.labelPositionAlongPath ?? 0.5;
+      const lp = pathPoint(p0, p1, control, labelT);
+      const tangent = pathPoint(p0, p1, control, Math.min(labelT + 0.03, 1)).sub(pathPoint(p0, p1, control, Math.max(labelT - 0.03, 0))).normalize();
+      const labelOffset = l.linkData.rendering?.labelOffsetFromPath ?? 0.15;
+      lp.addScaledVector(n, labelOffset);
+      l.labelObj.position.copy(lp);
+      if (l.linkData.rendering?.labelRotationBehavior === 'follow') {
+        const angle = Math.atan2(tangent.y, tangent.x);
+        l.labelObj.element.style.transform = `translate(-50%, -50%) rotate(${angle}rad)`;
+      } else {
+        l.labelObj.element.style.transform = 'translate(-50%, -50%)';
+      }
+    });
+  }
+}
+
+export function updateLinkFontSizes(camera) {
+  const p = new THREE.Vector3();
+  const c = new THREE.Vector3();
+  camera.getWorldPosition(c);
+  for (const label of linkLabels) {
+    label.getWorldPosition(p);
+    const d = Math.max(1, p.distanceTo(c));
+    const size = THREE.MathUtils.clamp(120 / d, 9, 18);
+    label.element.style.fontSize = `${size.toFixed(1)}px`;
+  }
+}

--- a/models/human_and_car_links.json
+++ b/models/human_and_car_links.json
@@ -1,0 +1,78 @@
+{
+  "hypergraph": {
+    "class": [
+      {
+        "id": 1,
+        "name": "Human",
+        "type": "roundedRectangle",
+        "attributes": ["Last name", "First name", "Age", "Occupation"],
+        "position": { "x": 20, "y": 5, "z": 0 },
+        "size": { "width": 1, "height": 2.2 },
+        "rendering": {
+          "class": { "color": "#FFD700", "borderColor": "#000080", "cornerRadius": 0.1 },
+          "attributes": { "checkboxColor": "#A9A9A9", "size": { "width": 0.1, "height": 0.1 } },
+          "connections": { "lineColor": "#000000", "lineWidth": 0.01 },
+          "textColor": "#000000"
+        }
+      },
+      {
+        "id": 2,
+        "name": "Car",
+        "type": "roundedRectangle",
+        "attributes": ["Make", "Model", "VIN", "Owner"],
+        "position": { "x": 24, "y": 5, "z": 0 },
+        "size": { "width": 1, "height": 2.2 },
+        "rendering": {
+          "class": { "color": "#00BFFF", "borderColor": "#000080", "cornerRadius": 0.1 },
+          "attributes": { "checkboxColor": "#A9A9A9", "size": { "width": 0.1, "height": 0.1 } },
+          "connections": { "lineColor": "#000000", "lineWidth": 0.01 },
+          "textColor": "#000000"
+        }
+      }
+    ],
+    "link": [
+      {
+        "sourceClassId": 1,
+        "targetClassId": 2,
+        "rendering": {
+          "lineColor": "#1a237e",
+          "lineWidth": 2,
+          "lineStyle": "solid",
+          "curveOffset": 0.5,
+          "arrowheadVisibility": true,
+          "arrowheadType": "triangle",
+          "arrowheadSize": 0.22,
+          "labelText": "drive",
+          "labelFontSize": 13,
+          "labelColor": "#0d1321",
+          "labelBackgroundColor": "rgba(255,255,255,0.95)",
+          "labelPositionAlongPath": 0.43,
+          "labelOffsetFromPath": 0.2,
+          "labelRotationBehavior": "follow",
+          "zIndex": 8
+        }
+      },
+      {
+        "sourceClassId": 1,
+        "targetClassId": 2,
+        "rendering": {
+          "lineColor": "#2e7d32",
+          "lineWidth": 2,
+          "lineStyle": "dashed",
+          "curveOffset": 0.5,
+          "arrowheadVisibility": true,
+          "arrowheadType": "triangle",
+          "arrowheadSize": 0.22,
+          "labelText": "own",
+          "labelFontSize": 13,
+          "labelColor": "#0b3d02",
+          "labelBackgroundColor": "rgba(255,255,255,0.95)",
+          "labelPositionAlongPath": 0.58,
+          "labelOffsetFromPath": -0.2,
+          "labelRotationBehavior": "follow",
+          "zIndex": 8
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Motivation
- Separate class-to-class link logic from class rendering so link routing, styling, and label/arrow handling live in a focused module. 
- Support multiple semantic links between the same two classes with non-overlapping curved paths and readable labels. 
- Keep links attached to each class's central red hub and recalculate routing on drag/zoom/resize so diagrams stay consistent. 

### Description
- Added a new module `js/hbds_class_link.js` which exports a small API including `Loader`, `createLinkBetweenClass`, `recalculateAllLinks`, and `updateLinkFontSizes`, and implements curved Bezier routing, parallel link offsets, arrowhead placement, and CSS2D link labels. 
- Implemented per-link rendering properties (line color/width/style, `curveOffset`, `arrowheadVisibility`, `arrowheadSize`, `labelText`, `labelFontSize`, `labelColor`, `labelBackgroundColor`, `labelPositionAlongPath`, `labelOffsetFromPath`, `labelRotationBehavior`, `zIndex`) consumed by the link module for rendering. 
- Updated `js/hbds_class.js` to expose each class hub with the name `class-hub` and store `userData.classId` so links can attach to the hub anchor. 
- Wired links into the scene in `index.html`: imports the link module, builds links from `model.hypergraph.link`, adds link groups to the diagram, and triggers `recalculateAllLinks()` / `updateLinkFontSizes()` on drag, zoom (orbit change), and resize so paths, arrowheads, and labels update dynamically. 
- Added `models/human_and_car_links.json` containing two `human -> car` links (`drive` and `own`) with distinct rendering properties so they render as separate curved links with independent labels and arrowheads. 

### Testing
- Ran `node --check js/hbds_class_link.js` and it succeeded. 
- Ran `node --check js/hbds_class.js` and it succeeded. 
- Verified repository changes with `git status --short` and created a commit for the change. 
- No failing automated tests were reported during this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6762529fc83318189e07f43727f39)