### PR TITLE
Fix crash when creating non-solid class links

### DIFF
--- a/js/hbds_class_link.js
+++ b/js/hbds_class_link.js
@@ -44,7 +44,6 @@ export function createLinkBetweenClass(linkData, classById) {
 
   const geometry = new THREE.BufferGeometry();
   const line = new THREE.Line(geometry, mat);
-  if (lineStyle !== 'solid') line.computeLineDistances();
   line.renderOrder = rendering.zIndex ?? 5;
 
   const arrow = new THREE.Mesh(


### PR DESCRIPTION
### Motivation
- Prevent a runtime `TypeError` caused by calling `THREE.Line.computeLineDistances()` on an empty `BufferGeometry` when creating dashed/dotted links.

### Description
- Remove the premature `computeLineDistances()` call from `createLinkBetweenClass()` so it is not invoked before the line geometry has points.
- Preserve the call to `computeLineDistances()` in `recalculateAllLinks()` where `setFromPoints()` has already initialized the geometry.

### Testing
- Ran `git diff -- js/hbds_class_link.js` to verify the change and it showed only the removed call, succeeding.
- Committed the change with `git commit -m "Fix link creation crash before line geometry initialization"` and the commit succeeded.
- Inspected the updated file with `nl -ba js/hbds_class_link.js | sed -n '35,110p'` to confirm `computeLineDistances()` is only called after `setFromPoints()`, and the inspection succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f678ad75848331bfe25200c691515d)