### PR TITLE
Fix link rendering position after diagram recentering

### DIFF
--- a/js/hbds_class_link.js
+++ b/js/hbds_class_link.js
@@ -12,10 +12,13 @@ export const Loader = {
   }
 };
 
-function getHubWorldPosition(classMesh) {
+function getHubPositionInParentSpace(classMesh, parentObject) {
   const hub = classMesh.getObjectByName('class-hub');
-  if (!hub) return classMesh.getWorldPosition(new THREE.Vector3());
-  return hub.getWorldPosition(new THREE.Vector3());
+  const worldPos = hub
+    ? hub.getWorldPosition(new THREE.Vector3())
+    : classMesh.getWorldPosition(new THREE.Vector3());
+
+  return parentObject ? parentObject.worldToLocal(worldPos.clone()) : worldPos;
 }
 
 function pathPoint(p0, p1, c, t) {
@@ -84,8 +87,9 @@ export function recalculateAllLinks() {
   for (const bucket of pairBuckets.values()) {
     const count = bucket.length;
     bucket.forEach((l, idx) => {
-      const p0 = getHubWorldPosition(l.sourceClass);
-      const p1 = getHubWorldPosition(l.targetClass);
+      const parent = l.linkGroup.parent;
+      const p0 = getHubPositionInParentSpace(l.sourceClass, parent);
+      const p1 = getHubPositionInParentSpace(l.targetClass, parent);
       const mid = new THREE.Vector3().addVectors(p0, p1).multiplyScalar(0.5);
       const dir = new THREE.Vector3().subVectors(p1, p0);
       const n = new THREE.Vector3(-dir.y, dir.x, 0).normalize();


### PR DESCRIPTION
### Motivation
- Links were being computed in world space while link geometry lived in a parent-local coordinate frame, causing curves, arrows, and labels to appear misplaced or invisible after the diagram group is recentered.

### Description
- Added `getHubPositionInParentSpace(classMesh, parentObject)` which obtains the hub world position (or class mesh position) and converts it to the provided parent's local space with `parentObject.worldToLocal(worldPos.clone())`.
- Updated `recalculateAllLinks` to use `l.linkGroup.parent` and call the new helper for both source and target hubs before computing bezier points, arrow placement, and label positions.
- Preserved existing link styling, arrow, and label logic while ensuring link geometry is constructed in the same coordinate space as its parent group.

### Testing
- Ran `git diff -- js/hbds_class_link.js` to verify the diff and it showed the intended changes (succeeded).
- Committed the change with `git add js/hbds_class_link.js && git commit -m "Fix link rendering position after diagram recentering"` and the commit completed successfully.
- Inspected the patched file with `nl -ba js/hbds_class_link.js | sed -n '1,180p'` to confirm the new helper and updated calls are present (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f67a8658108331a11cd3e2bee37ccf)