### PR TITLE
Add Hyperclass support and Mail Carrier model

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
             <option value="transportation">transportation</option>
             <option value="human_and_car_links">human_and_car_links</option>
             <option value="bridge_road_links">bridge_road_links</option>
+            <option value="models/hyperclass_mail_Carrier.json">Hyperclass Mail Carrier</option>
         </select>
     </div>
     <div class="control-group">
@@ -43,8 +44,9 @@
     import {DragControls} from 'three/addons/controls/DragControls.js';
     import {CSS2DRenderer} from 'three/addons/renderers/CSS2DRenderer.js';
     import {Loader as ClassLoader, createClass, updateLabelFontSizes} from './js/hbds_class.js';
-    import { Loader, createLinkBetweenClass, updateLinkFontSizes } from './js/hbds_class_link.js';
-    import { recalculateAllLinks } from './js/hbds_class_link.js';
+    import {Loader as HyperClassLoader, createHyperClass, updateLabelFontSizes as updateHyperClassLabelFontSizes} from './js/hbds_hyperclass_class.js';
+    import { createLinkBetweenClass, updateLinkFontSizes, recalculateAllLinks } from './js/hbds_class_link.js';
+    import { Loader as HyperClassLinkLoader, createLinkBetweenHyperClass, updateLinkFontSizes as updateHyperClassLinkFontSizes } from './js/hbds_hyperclass_link.js';
 
     /* ---------- Globals ---------- */
     let scene, camera, renderer, css2DRenderer, orbitControls, dragControls;
@@ -101,21 +103,27 @@
         }
         if (dragControls) dragControls.dispose();
 
-        const data = await ClassLoader.load(modelName);
+        const data = await HyperClassLoader.load(modelName);
         diagramGroup = new THREE.Group();
         scene.add(diagramGroup);
 
         const classById = new Map();
         data.hypergraph.class.forEach(cd => {
-            const {classMesh} = createClass(cd);
-            classMesh.position.set(cd.position.x, cd.position.y, cd.position.z);
+            const factory = cd.type === 'hyperclass' ? createHyperClass : createClass;
+            const { classMesh } = factory(null, cd);
+            if (cd.type !== 'hyperclass') classMesh.position.set(cd.position.x, cd.position.y, cd.position.z);
             diagramGroup.add(classMesh);
-            draggableObjects.push(classMesh);  // only the rectangle is the handle
+            draggableObjects.push(classMesh);
             classById.set(cd.id, classMesh);
         });
 
         (data.hypergraph.link || []).forEach(ld => {
-            const link = createLinkBetweenClass(ld, classById);
+            const sourceObject = classById.get(ld.sourceClassId);
+            const targetObject = classById.get(ld.targetClassId);
+            const hasHyperEndpoint = sourceObject?.userData?.isHyperClass || targetObject?.userData?.isHyperClass;
+            const link = hasHyperEndpoint
+                ? createLinkBetweenHyperClass(diagramGroup, sourceObject, targetObject, ld)
+                : createLinkBetweenClass(ld, classById);
             if (link) diagramGroup.add(link.linkGroup);
         });
 
@@ -130,13 +138,17 @@
         //updateLabelFontSizes(camera);
         orbitControls.addEventListener('change', () => {
             updateLabelFontSizes(camera);
+            updateHyperClassLabelFontSizes(camera, renderer);
             updateLinkFontSizes(camera);
+            updateHyperClassLinkFontSizes(camera, renderer);
             recalculateAllLinks();
             renderer.render(scene, camera);
             css2DRenderer.render(scene, camera);
         });
         updateLabelFontSizes(camera);
+        updateHyperClassLabelFontSizes(camera, renderer);
         updateLinkFontSizes(camera);
+        updateHyperClassLinkFontSizes(camera, renderer);
         recalculateAllLinks();
         renderer.render(scene, camera);
         css2DRenderer.render(scene, camera);
@@ -168,7 +180,9 @@
         renderer.setSize(window.innerWidth, window.innerHeight);
         css2DRenderer.setSize(window.innerWidth, window.innerHeight);
         updateLabelFontSizes(camera);
+        updateHyperClassLabelFontSizes(camera, renderer);
         updateLinkFontSizes(camera);
+        updateHyperClassLinkFontSizes(camera, renderer);
         recalculateAllLinks();
         renderer.render(scene, camera);
         css2DRenderer.render(scene, camera);

--- a/js/hbds_hyperclass_class.js
+++ b/js/hbds_hyperclass_class.js
@@ -1,0 +1,127 @@
+import * as THREE from 'three';
+import { CSS2DObject } from 'three/addons/renderers/CSS2DRenderer.js';
+
+const hyperclassLabels = [];
+
+export const Loader = {
+  async load(modelNameOrPath) {
+    const modelPath = modelNameOrPath.endsWith('.json')
+      ? `./${modelNameOrPath.replace(/^\.\//, '')}`
+      : `./models/${modelNameOrPath}.json`;
+    const res = await fetch(modelPath);
+    if (!res.ok) throw new Error(`Model not found: ${modelNameOrPath}`);
+    return await res.json();
+  }
+};
+
+export function createHyperClass(scene, hyperClassData, options = {}) {
+  const sz = hyperClassData.size ?? { width: 4, height: 4 };
+  const classCfg = hyperClassData.rendering?.class ?? {};
+  const textColor = hyperClassData.rendering?.textColor ?? '#000000';
+
+  const shape = roundedRect(sz.width, sz.height, classCfg.cornerRadius ?? 0.3);
+  const geom = new THREE.ExtrudeGeometry(shape, { depth: 0.03, bevelEnabled: false });
+  const mat = new THREE.MeshStandardMaterial({
+    color: classCfg.color ?? '#FFFFFF',
+    transparent: true,
+    opacity: classCfg.opacity ?? 0.14,
+    metalness: 0.9,
+    roughness: 0.35
+  });
+
+  const hyperMesh = new THREE.Mesh(geom, mat);
+  hyperMesh.position.set(
+    hyperClassData.position?.x ?? 0,
+    hyperClassData.position?.y ?? 0,
+    hyperClassData.position?.z ?? 0
+  );
+
+  const border = new THREE.LineSegments(
+    new THREE.EdgesGeometry(geom),
+    new THREE.LineBasicMaterial({ color: classCfg.borderColor ?? '#111111' })
+  );
+  hyperMesh.add(border);
+
+  const titleDiv = document.createElement('div');
+  titleDiv.className = 'label class-label hyperclass-label';
+  titleDiv.style.font = 'bold 18px Arial';
+  titleDiv.style.color = textColor;
+  titleDiv.textContent = hyperClassData.name ?? 'Hyperclass';
+  const title = new CSS2DObject(titleDiv);
+  title.position.set(0, sz.height / 2 - 0.22, 0.08);
+  hyperMesh.add(title);
+  hyperclassLabels.push(title);
+
+  const hub = new THREE.Mesh(
+    new THREE.CircleGeometry(0.04, 24),
+    new THREE.MeshBasicMaterial({ color: '#FF0000' })
+  );
+  hub.name = 'class-hub';
+  hub.position.set((sz.width * 0.85) / 2, (sz.height * 0.85) / 2, 0.08);
+  hub.raycast = () => {};
+  hyperMesh.add(hub);
+
+  hyperMesh.userData = {
+    ...hyperMesh.userData,
+    classId: hyperClassData.id,
+    classType: 'hyperclass',
+    isHyperClass: true,
+    children: hyperClassData.children ?? [],
+    parentClassId: hyperClassData.parentClassId ?? null,
+    sourceData: hyperClassData,
+    selectable: true,
+    editable: true,
+    deletable: true,
+    draggable: true
+  };
+
+  if (Array.isArray(hyperClassData.attributes)) {
+    const startY = sz.height / 2 - 0.45;
+    hyperClassData.attributes.forEach((attr, i) => {
+      const div = document.createElement('div');
+      div.className = 'label attribute-label hyperclass-attribute-label';
+      div.style.color = textColor;
+      div.style.font = '12px Arial';
+      div.textContent = attr;
+      const lbl = new CSS2DObject(div);
+      lbl.center.set(0, 0.5);
+      lbl.position.set(sz.width / 2 + 0.28, startY - i * 0.16, 0.08);
+      hyperMesh.add(lbl);
+      hyperclassLabels.push(lbl);
+    });
+  }
+
+  if (scene) scene.add(hyperMesh);
+  return { classMesh: hyperMesh };
+}
+
+export function updateLabelFontSizes(camera, renderer, options = {}) {
+  const wp = new THREE.Vector3();
+  const cp = new THREE.Vector3();
+  camera.getWorldPosition(cp);
+  hyperclassLabels.forEach(label => {
+    label.getWorldPosition(wp);
+    const dist = Math.max(1, wp.distanceTo(cp));
+    const isTitle = label.element.classList.contains('class-label');
+    const size = isTitle
+      ? THREE.MathUtils.clamp(160 / dist, 14, 32)
+      : THREE.MathUtils.clamp(100 / dist, 8, 16);
+    label.element.style.fontSize = `${size.toFixed(1)}px`;
+  });
+}
+
+function roundedRect(w, h, r) {
+  const s = new THREE.Shape();
+  const x = -w / 2;
+  const y = -h / 2;
+  s.moveTo(x, y + r);
+  s.lineTo(x, y + h - r);
+  s.quadraticCurveTo(x, y + h, x + r, y + h);
+  s.lineTo(x + w - r, y + h);
+  s.quadraticCurveTo(x + w, y + h, x + w, y + h - r);
+  s.lineTo(x + w, y + r);
+  s.quadraticCurveTo(x + w, y, x + w - r, y);
+  s.lineTo(x + r, y);
+  s.quadraticCurveTo(x, y, x, y + r);
+  return s;
+}

--- a/js/hbds_hyperclass_link.js
+++ b/js/hbds_hyperclass_link.js
@@ -1,0 +1,10 @@
+export { Loader, updateLinkFontSizes, recalculateAllLinks } from './hbds_class_link.js';
+import { createLinkBetweenClass } from './hbds_class_link.js';
+
+export function createLinkBetweenHyperClass(scene, sourceObject, targetObject, linkData, options = {}) {
+  const classById = new Map([
+    [linkData.sourceClassId, sourceObject],
+    [linkData.targetClassId, targetObject]
+  ]);
+  return createLinkBetweenClass(linkData, classById);
+}

--- a/models/hyperclass_mail_Carrier.json
+++ b/models/hyperclass_mail_Carrier.json
@@ -1,0 +1,123 @@
+{
+  "hypergraph": {
+    "class": [
+      {
+        "id": 1,
+        "name": "Mail Carrier",
+        "type": "ellipse",
+        "attributes": ["Last name", "First name", "Employee ID", "Delivery route", "Post office", "Phone number"],
+        "position": { "x": 5.5, "y": 8.2, "z": 0 },
+        "size": { "width": 3.2, "height": 1.25 },
+        "rendering": {
+          "class": { "color": "#FFFFFF", "material": "flat", "borderColor": "#000000", "borderWidth": 0.02, "cornerRadius": 0.1, "opacity": 0.2 },
+          "attributes": { "checkboxColor": "#FFFFFF", "checkboxMaterial": "flat", "shape": "circle", "size": { "width": 0.14, "height": 0.14 } },
+          "connections": { "lineColor": "#000000", "lineWidth": 0.01 },
+          "textColor": "#000000"
+        }
+      },
+      {
+        "id": 2,
+        "name": "Person",
+        "type": "ellipse",
+        "attributes": ["Last name", "First name", "Address", "Phone number", "Email"],
+        "position": { "x": 13.5, "y": 8.2, "z": 0 },
+        "size": { "width": 3.2, "height": 1.25 },
+        "rendering": {
+          "class": { "color": "#FFFFFF", "material": "flat", "borderColor": "#000000", "borderWidth": 0.02, "cornerRadius": 0.1, "opacity": 0.2 },
+          "attributes": { "checkboxColor": "#FFFFFF", "checkboxMaterial": "flat", "shape": "circle", "size": { "width": 0.14, "height": 0.14 } },
+          "connections": { "lineColor": "#000000", "lineWidth": 0.01 },
+          "textColor": "#000000"
+        }
+      },
+      {
+        "id": 3,
+        "name": "Mail",
+        "type": "hyperclass",
+        "attributes": ["Mail ID", "Sent date", "Received date", "Status", "Weight", "Priority", "Tracking code"],
+        "children": [4, 5],
+        "position": { "x": 9.5, "y": 4.8, "z": 0 },
+        "size": { "width": 4.1, "height": 5.3 },
+        "rendering": {
+          "class": { "color": "#FFFFFF", "material": "flat", "borderColor": "#000000", "borderWidth": 0.02, "cornerRadius": 0.3, "opacity": 0.12 },
+          "attributes": { "checkboxColor": "#FFFFFF", "checkboxMaterial": "flat", "shape": "circle", "size": { "width": 0.14, "height": 0.14 } },
+          "connections": { "lineColor": "#000000", "lineWidth": 0.01 },
+          "textColor": "#000000"
+        }
+      },
+      {
+        "id": 4,
+        "name": "Letter",
+        "type": "ellipse",
+        "attributes": ["Format", "Weight", "Stamp", "Sender address", "Recipient address"],
+        "parentClassId": 3,
+        "position": { "x": 9.5, "y": 5.4, "z": 0 },
+        "size": { "width": 3.1, "height": 1.25 },
+        "rendering": {
+          "class": { "color": "#FFFFFF", "material": "flat", "borderColor": "#000000", "borderWidth": 0.02, "cornerRadius": 0.1, "opacity": 0.2 },
+          "attributes": { "checkboxColor": "#FFFFFF", "checkboxMaterial": "flat", "shape": "circle", "size": { "width": 0.14, "height": 0.14 } },
+          "connections": { "lineColor": "#000000", "lineWidth": 0.01 },
+          "textColor": "#000000"
+        }
+      },
+      {
+        "id": 5,
+        "name": "Package",
+        "type": "ellipse",
+        "attributes": ["Dimensions", "Weight", "Contents", "Fragile", "Insurance", "Tracking code"],
+        "parentClassId": 3,
+        "position": { "x": 9.5, "y": 3.1, "z": 0 },
+        "size": { "width": 3.1, "height": 1.25 },
+        "rendering": {
+          "class": { "color": "#FFFFFF", "material": "flat", "borderColor": "#000000", "borderWidth": 0.02, "cornerRadius": 0.1, "opacity": 0.2 },
+          "attributes": { "checkboxColor": "#FFFFFF", "checkboxMaterial": "flat", "shape": "circle", "size": { "width": 0.14, "height": 0.14 } },
+          "connections": { "lineColor": "#000000", "lineWidth": 0.01 },
+          "textColor": "#000000"
+        }
+      }
+    ],
+    "link": [
+      {
+        "sourceClassId": 1,
+        "targetClassId": 3,
+        "rendering": {
+          "lineColor": "#000000",
+          "lineWidth": 2,
+          "lineStyle": "solid",
+          "curveOffset": -0.65,
+          "arrowheadVisibility": true,
+          "arrowheadType": "triangle",
+          "arrowheadSize": 0.22,
+          "labelText": "sends",
+          "labelFontSize": 13,
+          "labelColor": "#000000",
+          "labelBackgroundColor": "rgba(255,255,255,0.95)",
+          "labelPositionAlongPath": 0.42,
+          "labelOffsetFromPath": 0.2,
+          "labelRotationBehavior": "follow",
+          "zIndex": 8
+        }
+      },
+      {
+        "sourceClassId": 3,
+        "targetClassId": 2,
+        "rendering": {
+          "lineColor": "#000000",
+          "lineWidth": 2,
+          "lineStyle": "solid",
+          "curveOffset": 0.65,
+          "arrowheadVisibility": true,
+          "arrowheadType": "triangle",
+          "arrowheadSize": 0.22,
+          "labelText": "receives",
+          "labelFontSize": 13,
+          "labelColor": "#000000",
+          "labelBackgroundColor": "rgba(255,255,255,0.95)",
+          "labelPositionAlongPath": 0.42,
+          "labelOffsetFromPath": -0.2,
+          "labelRotationBehavior": "follow",
+          "zIndex": 8
+        }
+      }
+    ]
+  }
+}

--- a/models/hyperclass_mail_Carrier_with_links.json
+++ b/models/hyperclass_mail_Carrier_with_links.json
@@ -1,0 +1,123 @@
+{
+  "hypergraph": {
+    "class": [
+      {
+        "id": 1,
+        "name": "Mail Carrier",
+        "type": "ellipse",
+        "attributes": ["Last name", "First name", "Employee ID", "Delivery route", "Post office", "Phone number"],
+        "position": { "x": 5.5, "y": 8.2, "z": 0 },
+        "size": { "width": 3.2, "height": 1.25 },
+        "rendering": {
+          "class": { "color": "#FFFFFF", "material": "flat", "borderColor": "#000000", "borderWidth": 0.02, "cornerRadius": 0.1, "opacity": 0.2 },
+          "attributes": { "checkboxColor": "#FFFFFF", "checkboxMaterial": "flat", "shape": "circle", "size": { "width": 0.14, "height": 0.14 } },
+          "connections": { "lineColor": "#000000", "lineWidth": 0.01 },
+          "textColor": "#000000"
+        }
+      },
+      {
+        "id": 2,
+        "name": "Person",
+        "type": "ellipse",
+        "attributes": ["Last name", "First name", "Address", "Phone number", "Email"],
+        "position": { "x": 13.5, "y": 8.2, "z": 0 },
+        "size": { "width": 3.2, "height": 1.25 },
+        "rendering": {
+          "class": { "color": "#FFFFFF", "material": "flat", "borderColor": "#000000", "borderWidth": 0.02, "cornerRadius": 0.1, "opacity": 0.2 },
+          "attributes": { "checkboxColor": "#FFFFFF", "checkboxMaterial": "flat", "shape": "circle", "size": { "width": 0.14, "height": 0.14 } },
+          "connections": { "lineColor": "#000000", "lineWidth": 0.01 },
+          "textColor": "#000000"
+        }
+      },
+      {
+        "id": 3,
+        "name": "Mail",
+        "type": "hyperclass",
+        "attributes": ["Mail ID", "Sent date", "Received date", "Status", "Weight", "Priority", "Tracking code"],
+        "children": [4, 5],
+        "position": { "x": 9.5, "y": 4.8, "z": 0 },
+        "size": { "width": 4.1, "height": 5.3 },
+        "rendering": {
+          "class": { "color": "#FFFFFF", "material": "flat", "borderColor": "#000000", "borderWidth": 0.02, "cornerRadius": 0.3, "opacity": 0.12 },
+          "attributes": { "checkboxColor": "#FFFFFF", "checkboxMaterial": "flat", "shape": "circle", "size": { "width": 0.14, "height": 0.14 } },
+          "connections": { "lineColor": "#000000", "lineWidth": 0.01 },
+          "textColor": "#000000"
+        }
+      },
+      {
+        "id": 4,
+        "name": "Letter",
+        "type": "ellipse",
+        "attributes": ["Format", "Weight", "Stamp", "Sender address", "Recipient address"],
+        "parentClassId": 3,
+        "position": { "x": 9.5, "y": 5.4, "z": 0 },
+        "size": { "width": 3.1, "height": 1.25 },
+        "rendering": {
+          "class": { "color": "#FFFFFF", "material": "flat", "borderColor": "#000000", "borderWidth": 0.02, "cornerRadius": 0.1, "opacity": 0.2 },
+          "attributes": { "checkboxColor": "#FFFFFF", "checkboxMaterial": "flat", "shape": "circle", "size": { "width": 0.14, "height": 0.14 } },
+          "connections": { "lineColor": "#000000", "lineWidth": 0.01 },
+          "textColor": "#000000"
+        }
+      },
+      {
+        "id": 5,
+        "name": "Package",
+        "type": "ellipse",
+        "attributes": ["Dimensions", "Weight", "Contents", "Fragile", "Insurance", "Tracking code"],
+        "parentClassId": 3,
+        "position": { "x": 9.5, "y": 3.1, "z": 0 },
+        "size": { "width": 3.1, "height": 1.25 },
+        "rendering": {
+          "class": { "color": "#FFFFFF", "material": "flat", "borderColor": "#000000", "borderWidth": 0.02, "cornerRadius": 0.1, "opacity": 0.2 },
+          "attributes": { "checkboxColor": "#FFFFFF", "checkboxMaterial": "flat", "shape": "circle", "size": { "width": 0.14, "height": 0.14 } },
+          "connections": { "lineColor": "#000000", "lineWidth": 0.01 },
+          "textColor": "#000000"
+        }
+      }
+    ],
+    "link": [
+      {
+        "sourceClassId": 1,
+        "targetClassId": 3,
+        "rendering": {
+          "lineColor": "#000000",
+          "lineWidth": 2,
+          "lineStyle": "solid",
+          "curveOffset": -0.65,
+          "arrowheadVisibility": true,
+          "arrowheadType": "triangle",
+          "arrowheadSize": 0.22,
+          "labelText": "sends",
+          "labelFontSize": 13,
+          "labelColor": "#000000",
+          "labelBackgroundColor": "rgba(255,255,255,0.95)",
+          "labelPositionAlongPath": 0.42,
+          "labelOffsetFromPath": 0.2,
+          "labelRotationBehavior": "follow",
+          "zIndex": 8
+        }
+      },
+      {
+        "sourceClassId": 3,
+        "targetClassId": 2,
+        "rendering": {
+          "lineColor": "#000000",
+          "lineWidth": 2,
+          "lineStyle": "solid",
+          "curveOffset": 0.65,
+          "arrowheadVisibility": true,
+          "arrowheadType": "triangle",
+          "arrowheadSize": 0.22,
+          "labelText": "receives",
+          "labelFontSize": 13,
+          "labelColor": "#000000",
+          "labelBackgroundColor": "rgba(255,255,255,0.95)",
+          "labelPositionAlongPath": 0.42,
+          "labelOffsetFromPath": -0.2,
+          "labelRotationBehavior": "follow",
+          "zIndex": 8
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Motivation
- Add full Hyperclass support so the visualizer can treat container-like classes (hyperclasses) as first-class objects that contain child classes and participate in links.
- Provide a concrete example model (`Hyperclass Mail Carrier`) that demonstrates class↔hyperclass and hyperclass↔class links and nested children (Mail → Letter, Package).

### Description
- Added `js/hbds_hyperclass_class.js` exporting `Loader`, `createHyperClass`, and `updateLabelFontSizes`, which render a hyperclass container, attributes, labels, hub, and expose metadata in `userData` for selection/drag/edit workflows.
- Added `js/hbds_hyperclass_link.js` exporting `Loader`, `createLinkBetweenHyperClass` and re-exporting link helpers from `hbds_class_link.js`, routing links that involve hyperclasses into the existing link rendering pipeline.
- Updated `index.html` to import hyperclass modules with distinct aliases (`HyperClassLoader`, `HyperClassLinkLoader`), add the model selector option for `models/hyperclass_mail_Carrier.json`, use a factory dispatch (`cd.type === 'hyperclass' ? createHyperClass : createClass`) for loading classes, keep a unified `classById` map, and route link creation to `createLinkBetweenHyperClass` when either endpoint is a hyperclass.
- Added `models/hyperclass_mail_Carrier.json` and `models/hyperclass_mail_Carrier_with_links.json` containing the Mail (hyperclass), Mail Carrier, Person, children (Letter, Package), and the `sends` / `receives` links with rendering metadata.
- Integrated hyperclass label and hyperclass link font-size update hooks into the animation/resize/orbit change flows by calling `updateHyperClassLabelFontSizes` and `updateHyperClassLinkFontSizes` alongside existing label/link updates.

### Testing
- Ran a JSON validation and duplicate-ID check with: `python - <<'PY' ...` against `models/hyperclass_mail_Carrier.json` and `models/hyperclass_mail_Carrier_with_links.json`, and it passed (`json ok`).
- Verified repository state with `git status` and committed the changes (commit created successfully with the new files).
- Note: UI/browser runtime tests (model selection in the running viewer, drag/update behavior, visual regression, and console checks) were not executed in this headless environment and should be run in a browser as part of the mandatory test checklist before final delivery.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f776f6109883318ae1adfcfb1da154)