### PR TITLE
Fix crash when non-hyper classes received null in createClass

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,9 +109,11 @@
 
         const classById = new Map();
         data.hypergraph.class.forEach(cd => {
-            const factory = cd.type === 'hyperclass' ? createHyperClass : createClass;
-            const { classMesh } = factory(null, cd);
-            if (cd.type !== 'hyperclass') classMesh.position.set(cd.position.x, cd.position.y, cd.position.z);
+            const isHyperClass = cd.type === 'hyperclass';
+            const { classMesh } = isHyperClass
+                ? createHyperClass(null, cd)
+                : createClass(cd);
+            if (!isHyperClass) classMesh.position.set(cd.position.x, cd.position.y, cd.position.z);
             diagramGroup.add(classMesh);
             draggableObjects.push(classMesh);
             classById.set(cd.id, classMesh);


### PR DESCRIPTION
### Motivation
- The scene loader could call `createClass` with `null` as the first argument which caused `TypeError: Cannot read properties of null (reading 'size')` during rendering of normal class nodes.

### Description
- Replace the previous factory invocation with an explicit `isHyperClass` branch and call `createHyperClass(null, cd)` for hyperclasses or `createClass(cd)` for normal classes.
- Update the position assignment to run only for non-hyper classes by checking `!isHyperClass` before applying `classMesh.position.set(...)`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f77accd984833189332a463463b686)