### PR TITLE
Render hyperclass attributes and attach child classes so dragging parent moves children

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,8 +115,24 @@
                 : createClass(cd);
             if (!isHyperClass) classMesh.position.set(cd.position.x, cd.position.y, cd.position.z);
             diagramGroup.add(classMesh);
-            draggableObjects.push(classMesh);
             classById.set(cd.id, classMesh);
+        });
+
+        data.hypergraph.class.forEach(cd => {
+            if (!cd.parentClassId) return;
+            const parent = classById.get(cd.parentClassId);
+            const child = classById.get(cd.id);
+            if (!parent || !child) return;
+
+            const childWorld = child.getWorldPosition(new THREE.Vector3());
+            parent.worldToLocal(childWorld);
+            diagramGroup.remove(child);
+            child.position.copy(childWorld);
+            parent.add(child);
+        });
+
+        data.hypergraph.class.forEach(cd => {
+            if (!cd.parentClassId) draggableObjects.push(classById.get(cd.id));
         });
 
         (data.hypergraph.link || []).forEach(ld => {

--- a/js/hbds_class.js
+++ b/js/hbds_class.js
@@ -134,35 +134,55 @@ export function createClass(classData) {
 
 
     /* — Attributes: cube + line + label — */
-    const cbW = cfg.attributes.size.width;
-    const cbH = cfg.attributes.size.height ?? cbW;
-    const gapY = 0.15;                                           // vertical spacing
-    const startY = sz.height / 2 - 0.1;
-    const colX = sz.width / 2 + 0.25 + cbW;                  // cube centre X
+    attachAttributesToMesh(classMesh, classData.attributes ?? [], {
+        size: sz,
+        attributes: cfg.attributes,
+        connections: cfg.connections,
+        textColor: cfg.textColor,
+        hubPosition: hubPos,
+        z: Z_OVERLAY
+    });
 
-    (classData.attributes ?? []).forEach((attrName, idx) => {
+    return {classMesh};
+}
+
+export function attachAttributesToMesh(classMesh, attributes, options = {}) {
+    const size = options.size ?? {width: 1, height: 2};
+    const attrCfg = options.attributes ?? {checkboxColor: "#A9A9A9", size: {width: 0.1, height: 0.1}};
+    const connCfg = options.connections ?? {lineColor: "#000000", lineWidth: 0.01};
+    const textColor = options.textColor ?? "#000000";
+
+    const cbW = attrCfg.size.width;
+    const cbH = attrCfg.size.height ?? cbW;
+    const gapY = options.gapY ?? 0.15;
+    const startY = options.startY ?? (size.height / 2 - 0.1);
+    const colX = options.colX ?? (size.width / 2 + 0.25 + cbW);
+    const hubPos = options.hubPosition ?? new THREE.Vector3((size.width * 0.9) / 2, (size.height * 0.9) / 2, options.z ?? 0.06);
+    const z = options.z ?? 0.06;
+
+    attributes.forEach((attrName, idx) => {
         const y = startY - idx * gapY;
 
         // checkbox cube
         const cube = new THREE.Mesh(
             new THREE.BoxGeometry(cbW, cbH, cbW),
             new THREE.MeshStandardMaterial({
-                color: cfg.attributes.checkboxColor,
+                color: attrCfg.checkboxColor,
                 metalness: 1,
                 roughness: 0.25
             })
         );
-        cube.position.set(colX, y, Z_OVERLAY);
+        cube.position.set(colX, y, z);
         cube.raycast = () => {
         };
         classMesh.add(cube);
 
         // connecting line
         const line = new THREE.Line(
-            new THREE.BufferGeometry().setFromPoints([hubPos, cube.position]),
+            new THREE.BufferGeometry().setFromPoints([hubPos, cube.position.clone()]),
             new THREE.LineBasicMaterial({
-                color: cfg.connections.lineColor,
-                linewidth: cfg.connections.lineWidth
+                color: connCfg.lineColor,
+                linewidth: connCfg.lineWidth
             })
         );
         line.raycast = () => {
@@ -172,17 +192,15 @@ export function createClass(classData) {
         // attribute label
         const aDiv = document.createElement('div');
         aDiv.className = 'label attribute-label';
-        aDiv.style.color = cfg.textColor;
+        aDiv.style.color = textColor;
         aDiv.style.font = '12px Arial';
         aDiv.textContent = attrName;
         const aLbl = new CSS2DObject(aDiv);
-        aLbl.position.set(colX + cbW + 0.12, y, Z_OVERLAY);
+        aLbl.position.set(colX + cbW + 0.12, y, z);
         aLbl.center.set(0, 0.5);
         classMesh.add(aLbl);
         labels.push(aLbl);
     });
-
-    return {classMesh};
 }
 /**
  * NEW: Dynamically scales CSS2D labels based on camera distance.

--- a/js/hbds_hyperclass_class.js
+++ b/js/hbds_hyperclass_class.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { CSS2DObject } from 'three/addons/renderers/CSS2DRenderer.js';
+import { attachAttributesToMesh } from './hbds_class.js';
 
 const hyperclassLabels = [];
 
@@ -75,21 +76,27 @@ export function createHyperClass(scene, hyperClassData, options = {}) {
     draggable: true
   };
 
-  if (Array.isArray(hyperClassData.attributes)) {
-    const startY = sz.height / 2 - 0.45;
-    hyperClassData.attributes.forEach((attr, i) => {
-      const div = document.createElement('div');
-      div.className = 'label attribute-label hyperclass-attribute-label';
-      div.style.color = textColor;
-      div.style.font = '12px Arial';
-      div.textContent = attr;
-      const lbl = new CSS2DObject(div);
-      lbl.center.set(0, 0.5);
-      lbl.position.set(sz.width / 2 + 0.28, startY - i * 0.16, 0.08);
-      hyperMesh.add(lbl);
-      hyperclassLabels.push(lbl);
-    });
-  }
+  attachAttributesToMesh(hyperMesh, hyperClassData.attributes ?? [], {
+    size: sz,
+    attributes: {
+      checkboxColor: hyperClassData.rendering?.attributes?.checkboxColor ?? '#A9A9A9',
+      size: {
+        width: hyperClassData.rendering?.attributes?.size?.width ?? 0.1,
+        height: hyperClassData.rendering?.attributes?.size?.height ?? hyperClassData.rendering?.attributes?.size?.width ?? 0.1
+      }
+    },
+    connections: {
+      lineColor: hyperClassData.rendering?.connections?.lineColor ?? '#000000',
+      lineWidth: hyperClassData.rendering?.connections?.lineWidth ?? 0.01
+    },
+    textColor,
+    startY: sz.height / 2 - 0.45,
+    gapY: 0.16,
+    colX: sz.width / 2 + 0.28,
+    hubPosition: hub.position.clone(),
+    z: 0.08
+  });
+
 
   if (scene) scene.add(hyperMesh);
   return { classMesh: hyperMesh };


### PR DESCRIPTION
### Motivation
- Make hyperclass attributes render identically to normal class attributes (checkbox/marker, label, and hub-to-marker connection) for visual consistency.
- Ensure `Mail` acts as a true container for its child classes so `Letter` and `Package` remain visually and logically inside `Mail` and move with it.
- Reuse existing attribute rendering logic to avoid duplicating styles and to preserve `Letter`/`Package` behavior.

### Description
- Introduced `attachAttributesToMesh` in `js/hbds_class.js` to centralize attribute rendering (marker cube, connecting line, and CSS label) and font-scaling participation. 
- Updated `createClass` to call `attachAttributesToMesh` so existing class attribute rendering is preserved and reused. 
- Updated `js/hbds_hyperclass_class.js` to import and use `attachAttributesToMesh` so hyperclasses (e.g., `Mail`) render attributes with the same marker, label, and hub-to-attribute connections and configurable placement. 
- Modified scene build in `index.html` to reparent classes with `parentClassId` under their hyperclass while preserving world-to-local offsets and to register only top-level objects as direct drag targets so dragging a hyperclass moves its children automatically.

### Testing
- Ran repository-level verification commands including `rg`/`sed`/`nl` inspections and file diffs to confirm the new `attachAttributesToMesh` usage and reparenting logic were applied to `js/hbds_class.js`, `js/hbds_hyperclass_class.js`, and `index.html`, and these checks succeeded. 
- Created the PR metadata via the repository helper (PR creation step completed successfully). 
- Manual runtime verification was not executed in this change set; the code updates keep existing link recalculation and label-scaling hooks so runtime behavior (attribute lines, child movement, and link updates) should be handled by the existing render/drag listeners.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78bc335a88331b8126dffe6aae580)