### PR TITLE
Refactor HBDS model load/render/save into js/hbds_model.js and add Save Model UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,9 @@
             <span>Enable 3-D View</span>
         </label>
     </div>
+    <div class="control-group">
+        <button id="save-model-button">Save Model</button>
+    </div>
 </div>
 <script type="importmap">
     {
@@ -45,10 +48,11 @@
     import {OrbitControls} from 'three/addons/controls/OrbitControls.js';
     import {DragControls} from 'three/addons/controls/DragControls.js';
     import {CSS2DRenderer} from 'three/addons/renderers/CSS2DRenderer.js';
-    import {Loader as ClassLoader, createClass, updateLabelFontSizes} from './js/hbds_class.js';
-    import {Loader as HyperClassLoader, createHyperClass, updateLabelFontSizes as updateHyperClassLabelFontSizes} from './js/hbds_hyperclass_class.js';
-    import { createLinkBetweenClass, updateLinkFontSizes, recalculateAllLinks } from './js/hbds_class_link.js';
-    import { Loader as HyperClassLinkLoader, createLinkBetweenHyperClass, updateLinkFontSizes as updateHyperClassLinkFontSizes } from './js/hbds_hyperclass_link.js';
+    import {updateLabelFontSizes} from './js/hbds_class.js';
+    import {updateLabelFontSizes as updateHyperClassLabelFontSizes} from './js/hbds_hyperclass_class.js';
+    import { updateLinkFontSizes, recalculateAllLinks } from './js/hbds_class_link.js';
+    import { updateLinkFontSizes as updateHyperClassLinkFontSizes } from './js/hbds_hyperclass_link.js';
+    import { loadAndRenderScene, saveScene } from './js/hbds_model.js';
 
     /* ---------- Globals ---------- */
     let scene, camera, renderer, css2DRenderer, orbitControls, dragControls;
@@ -87,91 +91,40 @@
 
         window.addEventListener('resize', onResize);
         document.getElementById('view-toggle').addEventListener('change', toggleView);
-        document.getElementById('model-select').addEventListener('change', e => loadAndRenderScene(e.target.value));
+        document.getElementById('save-model-button').addEventListener('click', () => {
+            saveScene(getModelContext(), {
+                fileName: 'hbds_saved_model.json'
+            });
+        });
+        document.getElementById('model-select').addEventListener('change', e => {
+            loadAndRenderScene(e.target.value, getModelContext());
+        });
 
-        loadAndRenderScene('human');
+        loadAndRenderScene('human', getModelContext());
     }
 
-    async function loadAndRenderScene(modelName) {
-        /* ----- clear previous ----- */
-        if (diagramGroup) {
-            scene.remove(diagramGroup);
-            draggableObjects.length = 0;
-            diagramGroup.traverse(c => {
-                if ((c.isMesh || c.isLine) && c.geometry) c.geometry.dispose();
-                if ((c.isMesh || c.isLine) && c.material) c.material.dispose();
-                if (c.isCSS2DObject) c.element.remove();
-            });
-        }
-        if (dragControls) dragControls.dispose();
 
-        const data = await HyperClassLoader.load(modelName);
-        diagramGroup = new THREE.Group();
-        scene.add(diagramGroup);
-
-        const classById = new Map();
-        data.hypergraph.class.forEach(cd => {
-            const isHyperClass = cd.type === 'hyperclass';
-            const { classMesh } = isHyperClass
-                ? createHyperClass(null, cd)
-                : createClass(cd);
-            if (!isHyperClass) classMesh.position.set(cd.position.x, cd.position.y, cd.position.z);
-            diagramGroup.add(classMesh);
-            classById.set(cd.id, classMesh);
-        });
-
-        data.hypergraph.class.forEach(cd => {
-            if (!cd.parentClassId) return;
-            const parent = classById.get(cd.parentClassId);
-            const child = classById.get(cd.id);
-            if (!parent || !child) return;
-
-            const childWorld = child.getWorldPosition(new THREE.Vector3());
-            parent.worldToLocal(childWorld);
-            diagramGroup.remove(child);
-            child.position.copy(childWorld);
-            parent.add(child);
-        });
-
-        data.hypergraph.class.forEach(cd => {
-            if (!cd.parentClassId) draggableObjects.push(classById.get(cd.id));
-        });
-
-        (data.hypergraph.link || []).forEach(ld => {
-            const sourceObject = classById.get(ld.sourceClassId);
-            const targetObject = classById.get(ld.targetClassId);
-            const hasHyperEndpoint = sourceObject?.userData?.isHyperClass || targetObject?.userData?.isHyperClass;
-            const link = hasHyperEndpoint
-                ? createLinkBetweenHyperClass(diagramGroup, sourceObject, targetObject, ld)
-                : createLinkBetweenClass(ld, classById);
-            if (link) diagramGroup.add(link.linkGroup);
-        });
-
-        // Center diagram
-        const box = new THREE.Box3().setFromObject(diagramGroup);
-        const center = box.getCenter(new THREE.Vector3());
-        diagramGroup.position.sub(center);
-        box.getBoundingSphere(diagramGroup.userData.boundingSphere = new THREE.Sphere());
-
-        setCamera2D();
-        setupDragControls();
-        //updateLabelFontSizes(camera);
-        orbitControls.addEventListener('change', () => {
-            updateLabelFontSizes(camera);
-            updateHyperClassLabelFontSizes(camera, renderer);
-            updateLinkFontSizes(camera);
-            updateHyperClassLinkFontSizes(camera, renderer);
-            recalculateAllLinks();
-            renderer.render(scene, camera);
-            css2DRenderer.render(scene, camera);
-        });
-        updateLabelFontSizes(camera);
-        updateHyperClassLabelFontSizes(camera, renderer);
-        updateLinkFontSizes(camera);
-        updateHyperClassLinkFontSizes(camera, renderer);
-        recalculateAllLinks();
+    function renderOnce() {
         renderer.render(scene, camera);
         css2DRenderer.render(scene, camera);
+    }
+
+    function getModelContext() {
+        return {
+            scene,
+            camera,
+            renderer,
+            css2DRenderer,
+            orbitControls,
+            dragControls,
+            diagramGroup,
+            draggableObjects,
+            setDiagramGroup: group => { diagramGroup = group; },
+            setDragControls: controls => { dragControls = controls; },
+            setupDragControls,
+            setCamera2D,
+            renderOnce
+        };
     }
 
     function setupDragControls() {
@@ -204,8 +157,7 @@
         updateLinkFontSizes(camera);
         updateHyperClassLinkFontSizes(camera, renderer);
         recalculateAllLinks();
-        renderer.render(scene, camera);
-        css2DRenderer.render(scene, camera);
+        renderOnce();
         camera.updateProjectionMatrix();
     }
 
@@ -238,8 +190,7 @@
         requestAnimationFrame(animate);
 
         if (orbitControls.enabled) orbitControls.update();
-        renderer.render(scene, camera);
-        css2DRenderer.render(scene, camera);
+        renderOnce();
     }
 
     /* ---------- START ---------- */

--- a/js/hbds_model.js
+++ b/js/hbds_model.js
@@ -1,0 +1,198 @@
+import * as THREE from 'three';
+
+import {
+  Loader as ClassLoader,
+  createClass,
+  updateLabelFontSizes
+} from './hbds_class.js';
+
+import {
+  Loader as HyperClassLoader,
+  createHyperClass,
+  updateLabelFontSizes as updateHyperClassLabelFontSizes
+} from './hbds_hyperclass_class.js';
+
+import {
+  createLinkBetweenClass,
+  updateLinkFontSizes,
+  recalculateAllLinks
+} from './hbds_class_link.js';
+
+import {
+  Loader as HyperClassLinkLoader,
+  createLinkBetweenHyperClass,
+  updateLinkFontSizes as updateHyperClassLinkFontSizes
+} from './hbds_hyperclass_link.js';
+
+function cloneModelData(data) {
+  return typeof structuredClone === 'function'
+    ? structuredClone(data)
+    : JSON.parse(JSON.stringify(data));
+}
+
+function stampNodeMetadata(classMesh, classData) {
+  classMesh.userData.modelData = cloneModelData(classData);
+  classMesh.userData.hbdsId = classData.id;
+  classMesh.userData.isHyperClass = classData.type === 'hyperclass';
+  classMesh.userData.isHbdsClass = true;
+}
+
+export async function loadAndRenderScene(modelName, context) {
+  const {
+    scene,
+    camera,
+    renderer,
+    css2DRenderer,
+    orbitControls,
+    dragControls,
+    diagramGroup,
+    draggableObjects,
+    setDiagramGroup,
+    setDragControls,
+    setupDragControls,
+    setCamera2D,
+    renderOnce
+  } = context;
+
+  if (diagramGroup) {
+    scene.remove(diagramGroup);
+    draggableObjects.length = 0;
+    diagramGroup.traverse(c => {
+      if ((c.isMesh || c.isLine) && c.geometry) c.geometry.dispose();
+      if ((c.isMesh || c.isLine) && c.material) c.material.dispose();
+      if (c.isCSS2DObject) c.element.remove();
+    });
+  }
+  if (dragControls) {
+    dragControls.dispose();
+    setDragControls(null);
+  }
+
+  const data = await HyperClassLoader.load(modelName);
+  const nextDiagramGroup = new THREE.Group();
+  scene.add(nextDiagramGroup);
+  setDiagramGroup(nextDiagramGroup);
+
+  const classById = new Map();
+  data.hypergraph.class.forEach(cd => {
+    const isHyperClass = cd.type === 'hyperclass';
+    const { classMesh } = isHyperClass
+      ? createHyperClass(null, cd)
+      : createClass(cd);
+
+    if (!isHyperClass) {
+      classMesh.position.set(cd.position.x, cd.position.y, cd.position.z);
+    }
+
+    stampNodeMetadata(classMesh, cd);
+    nextDiagramGroup.add(classMesh);
+    classById.set(cd.id, classMesh);
+  });
+
+  data.hypergraph.class.forEach(cd => {
+    if (!cd.parentClassId) return;
+    const parent = classById.get(cd.parentClassId);
+    const child = classById.get(cd.id);
+    if (!parent || !child) return;
+
+    const childWorld = child.getWorldPosition(new THREE.Vector3());
+    parent.worldToLocal(childWorld);
+    nextDiagramGroup.remove(child);
+    child.position.copy(childWorld);
+    parent.add(child);
+  });
+
+  data.hypergraph.class.forEach(cd => {
+    if (!cd.parentClassId) draggableObjects.push(classById.get(cd.id));
+  });
+
+  (data.hypergraph.link || []).forEach(ld => {
+    const sourceObject = classById.get(ld.sourceClassId);
+    const targetObject = classById.get(ld.targetClassId);
+    const hasHyperEndpoint = sourceObject?.userData?.isHyperClass || targetObject?.userData?.isHyperClass;
+    const link = hasHyperEndpoint
+      ? createLinkBetweenHyperClass(nextDiagramGroup, sourceObject, targetObject, ld)
+      : createLinkBetweenClass(ld, classById);
+
+    if (!link) return;
+
+    link.linkGroup.userData.linkData = cloneModelData(ld);
+    link.linkGroup.userData.sourceClassId = ld.sourceClassId;
+    link.linkGroup.userData.targetClassId = ld.targetClassId;
+    link.linkGroup.userData.isHbdsLink = true;
+    nextDiagramGroup.add(link.linkGroup);
+  });
+
+  const box = new THREE.Box3().setFromObject(nextDiagramGroup);
+  const center = box.getCenter(new THREE.Vector3());
+  nextDiagramGroup.position.sub(center);
+  box.getBoundingSphere(nextDiagramGroup.userData.boundingSphere = new THREE.Sphere());
+
+  setCamera2D();
+  setupDragControls();
+
+  orbitControls.addEventListener('change', () => {
+    updateLabelFontSizes(camera);
+    updateHyperClassLabelFontSizes(camera, renderer);
+    updateLinkFontSizes(camera);
+    updateHyperClassLinkFontSizes(camera, renderer);
+    recalculateAllLinks();
+    renderOnce();
+  });
+
+  updateLabelFontSizes(camera);
+  updateHyperClassLabelFontSizes(camera, renderer);
+  updateLinkFontSizes(camera);
+  updateHyperClassLinkFontSizes(camera, renderer);
+  recalculateAllLinks();
+  renderOnce();
+}
+
+export function saveScene(context, options = {}) {
+  const { diagramGroup } = context;
+  if (!diagramGroup) return;
+
+  const classEntries = [];
+  const linkEntries = [];
+
+  diagramGroup.traverse(obj => {
+    if (obj.userData?.isHbdsClass && obj.userData?.modelData) {
+      const savedClass = cloneModelData(obj.userData.modelData);
+      const worldPos = obj.getWorldPosition(new THREE.Vector3());
+      const localPos = diagramGroup.worldToLocal(worldPos.clone());
+
+      savedClass.position = {
+        x: localPos.x,
+        y: localPos.y,
+        z: localPos.z
+      };
+
+      classEntries.push(savedClass);
+    }
+
+    if (obj.userData?.isHbdsLink && obj.userData?.linkData) {
+      const savedLink = cloneModelData(obj.userData.linkData);
+      savedLink.sourceClassId = obj.userData.sourceClassId ?? savedLink.sourceClassId;
+      savedLink.targetClassId = obj.userData.targetClassId ?? savedLink.targetClassId;
+      linkEntries.push(savedLink);
+    }
+  });
+
+  const savedModel = {
+    hypergraph: {
+      class: classEntries,
+      link: linkEntries
+    }
+  };
+
+  const blob = new Blob([JSON.stringify(savedModel, null, 2)], {
+    type: 'application/json'
+  });
+
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = options.fileName || 'hbds_saved_model.json';
+  a.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
### Motivation
- Reduce complexity in `index.html` by moving model-specific loading, rendering, and saving logic into a dedicated module so the main file handles bootstrapping, renderer/camera/controls, and UI wiring.
- Provide a reliable save/export mechanism that captures the current scene state (including user-drug positions, child/parent relationships, and full link data) using the existing HBDS schema.

### Description
- Added new module `js/hbds_model.js` which exports `loadAndRenderScene(modelName, context)` and `saveScene(context, options = {})` and reuses existing loaders/helpers to create classes, hyperclasses, and links while stamping `userData` for later serialization.
- Updated `index.html` to import `loadAndRenderScene` and `saveScene`, added `getModelContext()` and a `renderOnce()` helper, wired the model selector to call `loadAndRenderScene(e.target.value, getModelContext())`, and replaced the inline `loadAndRenderScene` implementation with the module call (initial load uses `human`).
- Added a new control button `Save Model` inside `controls-panel` and wired it to call `saveScene(getModelContext(), { fileName: 'hbds_saved_model.json' })` to download the current scene as JSON in `{ "hypergraph": { "class": [], "link": [] } }` format.
- The module preserves original model/link payloads in `userData` (e.g., `modelData`, `hbdsId`, `isHyperClass`, link `linkData`) and computes saved positions from current scene transforms relative to the main `diagramGroup` so drag changes are captured.

### Testing
- Ran static verification searches to confirm `loadAndRenderScene` is no longer inline in `index.html` and that `index.html` now imports and calls `loadAndRenderScene(..., getModelContext())`, which succeeded.
- Verified the presence and exported signatures of `loadAndRenderScene` and `saveScene` in `js/hbds_model.js` and confirmed `js/hbds_model.js` was created, which succeeded.
- Performed file/diff inspection to confirm the `Save Model` button was added to the UI and wired to `saveScene`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f796f0cc788331a9be55452e82b653)