### PR TITLE
Use selected model filename when exporting model JSON

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,9 +92,12 @@
         window.addEventListener('resize', onResize);
         document.getElementById('view-toggle').addEventListener('change', toggleView);
         document.getElementById('save-model-button').addEventListener('click', () => {
-            saveScene(getModelContext(), {
-                fileName: 'hbds_saved_model.json'
-            });
+            const selectedModelValue = document.getElementById('model-select').value;
+            const fileName = selectedModelValue.endsWith('.json')
+                ? selectedModelValue.split('/').pop()
+                : `${selectedModelValue}.json`;
+
+            saveScene(getModelContext(), { fileName });
         });
         document.getElementById('model-select').addEventListener('change', e => {
             loadAndRenderScene(e.target.value, getModelContext());


### PR DESCRIPTION
### Motivation
- Make exported model filenames match the currently selected model so users can save a file with the same name (supporting both `models/...json` paths and shorthand model keys).

### Description
- Update the Save Model click handler in `index.html` to compute a `fileName` from the `#model-select` value (use the basename when the value ends with `.json`, otherwise append `.json`) and pass it to `saveScene`.

### Testing
- Verified the change via repository checks (`git diff -- index.html`) and committed the update successfully; no automated test suite is configured for this frontend change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7990120c48331ba48ea62a290ad1b)