### PR TITLE
Add geometry helpers and implement lineIntersectsBox to fix link routing error

### DIFF
--- a/js/hbds_model.js
+++ b/js/hbds_model.js
@@ -331,6 +331,29 @@ function seededRandom(seedText) { let seed = 0; for (let i = 0; i < seedText.len
 function makeBox(cx, cy, w, h) { return { minX: cx - w / 2, maxX: cx + w / 2, minY: cy - h / 2, maxY: cy + h / 2, width: w, height: h, cx, cy }; }
 function overlapArea(a, b) { const ox = Math.max(0, Math.min(a.maxX, b.maxX) - Math.max(a.minX, b.minX)); const oy = Math.max(0, Math.min(a.maxY, b.maxY) - Math.max(a.minY, b.minY)); return ox * oy; }
 function boxContains(outer, inner) { return inner.minX >= outer.minX && inner.maxX <= outer.maxX && inner.minY >= outer.minY && inner.maxY <= outer.maxY; }
+function pointInBox(point, box) { return point.x >= box.minX && point.x <= box.maxX && point.y >= box.minY && point.y <= box.maxY; }
+function segmentsIntersect(a, b, c, d) {
+  const orient = (p, q, r) => (q.x - p.x) * (r.y - p.y) - (q.y - p.y) * (r.x - p.x);
+  const onSegment = (p, q, r) => q.x >= Math.min(p.x, r.x) && q.x <= Math.max(p.x, r.x) && q.y >= Math.min(p.y, r.y) && q.y <= Math.max(p.y, r.y);
+  const o1 = orient(a, b, c), o2 = orient(a, b, d), o3 = orient(c, d, a), o4 = orient(c, d, b);
+  if (((o1 > 0 && o2 < 0) || (o1 < 0 && o2 > 0)) && ((o3 > 0 && o4 < 0) || (o3 < 0 && o4 > 0))) return true;
+  if (o1 === 0 && onSegment(a, c, b)) return true;
+  if (o2 === 0 && onSegment(a, d, b)) return true;
+  if (o3 === 0 && onSegment(c, a, d)) return true;
+  if (o4 === 0 && onSegment(c, b, d)) return true;
+  return false;
+}
+function lineIntersectsBox(start, end, rect) {
+  const box = makeBox(rect.x, rect.y, rect.width, rect.height);
+  if (pointInBox(start, box) || pointInBox(end, box)) return true;
+  const edges = [
+    [{ x: box.minX, y: box.minY }, { x: box.maxX, y: box.minY }],
+    [{ x: box.maxX, y: box.minY }, { x: box.maxX, y: box.maxY }],
+    [{ x: box.maxX, y: box.maxY }, { x: box.minX, y: box.maxY }],
+    [{ x: box.minX, y: box.maxY }, { x: box.minX, y: box.minY }]
+  ];
+  return edges.some(([e1, e2]) => segmentsIntersect(start, end, e1, e2));
+}
 
 function layoutChildrenForAllHyperclasses(layout, options) { layout.nodes.filter(n => n.isHyperClass).forEach(h => layoutChildrenInsideHyperclass(h, layout, options)); }
 function layoutChildrenInsideHyperclass(hyperNode, layout, options) {


### PR DESCRIPTION
### Motivation
- Layout optimization was throwing `ReferenceError: lineIntersectsBox is not defined` when routing links, causing `optimizeAndRefreshLayout` to fail.
- The link routing logic needs robust segment-vs-rectangle intersection checks to avoid false negatives when checking route collisions.

### Description
- Added `pointInBox`, `segmentsIntersect`, and `lineIntersectsBox` helper functions to `js/hbds_model.js` immediately after `boxContains` to provide endpoint-inside-box and segment-intersection tests.
- Implemented `lineIntersectsBox` to convert the rectangle into the internal `makeBox` format and test endpoints and each box edge with `segmentsIntersect`.
- The new helpers handle collinear and on-segment cases and are used by existing `routeIntersectsObstacle` logic so route collision checks can run safely.

### Testing
- Ran `git diff -- js/hbds_model.js` to verify the file changes and the diff output is present and correct (succeeded).
- Performed a quick syntax check with `node -e "const fs=require('fs');new Function(fs.readFileSync('js/hbds_model.js','utf8').replace(/^import .*$/mg,'')); console.log('ok')"` which failed due to naive import-stripping and ESM import syntax handling, not because of the added helpers (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b9bb8bc08331bff911b30349a0f0)