### PR TITLE
Add importmap to test_dynamic_hbds_layout.html to resolve Three.js imports

### DIFF
--- a/test_dynamic_hbds_layout.html
+++ b/test_dynamic_hbds_layout.html
@@ -18,6 +18,15 @@
     #layout-status { background: #111; color: #e7ffe7; padding: 8px; min-height: 130px; white-space: pre-wrap; }
     .label { pointer-events: none; }
   </style>
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://unpkg.com/three@0.176.0/build/three.module.js",
+    "three/addons/": "https://unpkg.com/three@0.176.0/examples/jsm/"
+  }
+}
+</script>
+
 </head>
 <body>
   <div id="container"></div>


### PR DESCRIPTION
### Motivation
- The test page used bare module specifiers like `three` which the browser could not resolve, causing `Failed to resolve module specifier "three"`; an import map is needed so those specifiers resolve to the same CDN URLs used by `index.html`.

### Description
- Inserted a `<script type="importmap">` block into `test_dynamic_hbds_layout.html` that maps `three` to `https://unpkg.com/three@0.176.0/build/three.module.js` and `three/addons/` to `https://unpkg.com/three@0.176.0/examples/jsm/`.

### Testing
- Ran repository checks and file verification commands (`rg`, `nl -ba`) and committed the change with `git add`/`git commit`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d6a783c083319ee2186e5717b1fe)