### PR TITLE
Keep selected node on top and add class/hyperclass metadata attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,8 +155,24 @@
     function setupDragControls() {
         dragControls = new DragControls(draggableObjects, camera, css2DRenderer.domElement); // unified target
         dragControls.transformGroup = false;
+        let selectedObject = null;
+        let selectedOrder = 1;
+
+        const setObjectRenderOrder = (object, order) => {
+            object.traverse?.(child => {
+                if (child.isMesh || child.isLine) {
+                    child.renderOrder = order;
+                }
+            });
+        };
 
         dragControls.addEventListener('dragstart', ev => {
+            if (selectedObject && selectedObject !== ev.object) {
+                setObjectRenderOrder(selectedObject, 1);
+            }
+            selectedObject = ev.object;
+            selectedOrder += 1;
+            setObjectRenderOrder(selectedObject, selectedOrder);
             orbitControls.enabled = false;
         });
 

--- a/js/hbds_class.js
+++ b/js/hbds_class.js
@@ -102,10 +102,14 @@ export function createClass(classData) {
     const classMesh = new THREE.Mesh(extrudeGeom, classMat);
     classMesh.position.z = Z_BASE;
     classMesh.userData.classId = classData.id;
+    classMesh.userData.classType = 'class';
+    classMesh.userData.isHyperClass = false;
 
     /* — Class name label (CSS2D) — */
     const titleDiv = document.createElement('div');
     titleDiv.className = 'label class-label';
+    titleDiv.setAttribute('data-class', classData.name ?? '');
+    titleDiv.setAttribute('data-hyperclass', 'false');
     titleDiv.style.color = cfg.textColor;
     titleDiv.style.font = 'bold 16px Arial';
     titleDiv.textContent = classData.name;

--- a/js/hbds_hyperclass_class.js
+++ b/js/hbds_hyperclass_class.js
@@ -45,6 +45,8 @@ export function createHyperClass(scene, hyperClassData, options = {}) {
 
   const titleDiv = document.createElement('div');
   titleDiv.className = 'label class-label hyperclass-label';
+  titleDiv.setAttribute('data-class', hyperClassData.name ?? '');
+  titleDiv.setAttribute('data-hyperclass', 'true');
   titleDiv.style.font = 'bold 18px Arial';
   titleDiv.style.color = textColor;
   titleDiv.textContent = hyperClassData.name ?? 'Hyperclass';

--- a/js/hbds_model.js
+++ b/js/hbds_model.js
@@ -34,6 +34,7 @@ function stampNodeMetadata(classMesh, classData) {
   classMesh.userData.modelData = cloneModelData(classData);
   classMesh.userData.hbdsId = classData.id;
   classMesh.userData.isHyperClass = classData.type === 'hyperclass';
+  classMesh.userData.classType = classData.type === 'hyperclass' ? 'hyperclass' : 'class';
   classMesh.userData.isHbdsClass = true;
 }
 


### PR DESCRIPTION
### Motivation
- Ensure the element the user selects/drags is always rendered on top so it remains visible during interactions.  
- Make class vs hyperclass identity available both in mesh `userData` and in the DOM so downstream code and CSS/DOM queries can reliably distinguish them.

### Description
- Promote the dragged object to the top render layer by tracking `selectedObject`/`selectedOrder` and setting `renderOrder` on meshes/lines inside `setupDragControls` in `index.html` so only the latest selected node stays on top.  
- Add explicit metadata to regular class meshes by setting `userData.classType = 'class'` and `userData.isHyperClass = false` in `js/hbds_class.js`, and normalize `classType` stamping in `js/hbds_model.js` so every node has a `classType` of either `class` or `hyperclass`.  
- Attach DOM attributes to title labels by adding `data-class` and `data-hyperclass` to both class title elements (`js/hbds_class.js`) and hyperclass title elements (`js/hbds_hyperclass_class.js`) for easier DOM-level identification.

### Testing
- No automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7da8e8848833188d340606b368809)