### PR TITLE
Add dynamic Selected Element checkbox menu and hyperclass mesh naming

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -77,6 +77,23 @@ select {
   height: 18px;
 }
 
+#selected-element-checkboxes {
+  max-height: 180px;
+  overflow: auto;
+  padding: 6px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: #fff;
+}
+
+.selected-element-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  margin: 4px 0;
+}
+
 /* ---------- CSS2D Labels ---------- */
 .label {
   color: #000;

--- a/index.html
+++ b/index.html
@@ -44,6 +44,10 @@
     <div class="control-group">
         <button id="fit-model-button">Fit Model</button>
     </div>
+    <div class="control-group" id="selected-element-menu">
+        <label>Selected Element</label>
+        <div id="selected-element-checkboxes"></div>
+    </div>
 </div>
 <script type="importmap">
     {

--- a/js/hbds_hyperclass_class.js
+++ b/js/hbds_hyperclass_class.js
@@ -31,6 +31,7 @@ export function createHyperClass(scene, hyperClassData, options = {}) {
   });
 
   const hyperMesh = new THREE.Mesh(geom, mat);
+  hyperMesh.name = `hyperclass-${hyperClassData.name ?? hyperClassData.id ?? 'node'}`;
   hyperMesh.position.set(
     hyperClassData.position?.x ?? 0,
     hyperClassData.position?.y ?? 0,

--- a/js/hbds_model.js
+++ b/js/hbds_model.js
@@ -70,6 +70,7 @@ export async function loadAndRenderScene(modelName, context) {
   }
 
   const data = await HyperClassLoader.load(modelName);
+  buildSelectedElementMenu(data);
   const nextDiagramGroup = new THREE.Group();
   scene.add(nextDiagramGroup);
   setDiagramGroup(nextDiagramGroup);
@@ -150,6 +151,40 @@ export async function loadAndRenderScene(modelName, context) {
   refreshDiagramBoundsAndCamera(context, { fitToView: true, padding: 1.25 });
   updateModelOverview(context);
   renderOnce();
+}
+
+function buildSelectedElementMenu(data) {
+  const container = document.getElementById('selected-element-checkboxes');
+  if (!container || !data?.hypergraph) return;
+  container.innerHTML = '';
+
+  const classes = data.hypergraph.class || [];
+  const links = data.hypergraph.link || [];
+  const classById = new Map(classes.map(c => [c.id, c.name || c.id]));
+
+  const options = [
+    ...classes
+      .filter(c => c.parentClassId)
+      .map(c => ({ key: `parent-${c.id}`, label: `Parent Hyperclass: ${classById.get(c.parentClassId)}` })),
+    ...classes.flatMap(c => (c.attributes || []).map(a => ({
+      key: `attribute-${c.id}-${a.name}`,
+      label: `Attribute Owner: ${c.name} → ${a.name}`
+    }))),
+    ...links.map(l => ({ key: `source-${l.id}`, label: `Link Source: ${classById.get(l.sourceClassId) || l.sourceClassId}` })),
+    ...links.map(l => ({ key: `target-${l.id}`, label: `Link Target: ${classById.get(l.targetClassId) || l.targetClassId}` }))
+  ];
+
+  options.forEach(option => {
+    const row = document.createElement('label');
+    row.className = 'selected-element-option';
+    const input = document.createElement('input');
+    input.type = 'checkbox';
+    input.dataset.optionKey = option.key;
+    const text = document.createElement('span');
+    text.textContent = option.label;
+    row.append(input, text);
+    container.appendChild(row);
+  });
 }
 
 export function saveScene(context, options = {}) {


### PR DESCRIPTION
### Motivation
- Remove references to a missing `js/hbds_setting.js`, add an identifiable class/mesh for hyperclasses, and replace static metadata text with dynamic, actionable UI controls.  
- Provide checkboxes generated from model data for the metadata categories previously shown as labels: `Parent Hyperclass`, `Attribute Owner`, `Link Source`, and `Link Target`.  

### Description
- Added a `Selected Element` control group and a `#selected-element-checkboxes` container in `index.html` to host the dynamic checkbox list.  
- Implemented `buildSelectedElementMenu(data)` in `js/hbds_model.js` and call it from `loadAndRenderScene` to populate checkboxes from `hypergraph.class` and `hypergraph.link`.  
- Added CSS rules in `css/style.css` for the checkbox list and row entries to make the list scrollable and styled.  
- Set a stable mesh `name` on hyperclass meshes in `js/hbds_hyperclass_class.js` (`hyperclass-<name|id>`) to improve identification in the scene graph.  

### Testing
- Performed a syntax check on `js/hbds_model.js` with `node --check` which succeeded.  
- Performed a syntax check on `js/hbds_hyperclass_class.js` with `node --check` which succeeded.  
- Attempted `node --check index.html` which is not applicable because Node cannot syntax-check `.html` modules directly (reported as an unknown file extension).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e9b1fd908331b08944111ef711f9)