### PR TITLE
Hub-to-hub routing and deterministic hyperclass child grid

### DIFF
--- a/js/hbds_class.js
+++ b/js/hbds_class.js
@@ -133,6 +133,21 @@ export function createClass(classData) {
     titleObj.raycast = () => {
     };
     classMesh.add(hub);
+
+    const hubTop = hub.clone();
+    hubTop.position.set(0, sz.height / 2 - 0.12, Z_OVERLAY);
+    const hubBottom = hub.clone();
+    hubBottom.position.set(0, -sz.height / 2 + 0.12, Z_OVERLAY);
+    const hubLeft = hub.clone();
+    hubLeft.position.set(-sz.width / 2 + 0.12, 0, Z_OVERLAY);
+    const hubRight = hub.clone();
+    hubRight.position.set(sz.width / 2 - 0.12, 0, Z_OVERLAY);
+    const hubCenter = hub.clone();
+    hubCenter.position.set(0, 0, Z_OVERLAY);
+    [hubTop, hubBottom, hubLeft, hubRight, hubCenter].forEach(h => { h.raycast = () => {}; classMesh.add(h); });
+    classMesh.userData.hubs = { top: hubTop, right: hubRight, bottom: hubBottom, left: hubLeft, center: hubCenter };
+    classMesh.userData.linkHub = hubCenter;
+
     classMesh.add(titleObj);
     labels.push(titleObj);
 

--- a/js/hbds_class_link.js
+++ b/js/hbds_class_link.js
@@ -12,14 +12,44 @@ export const Loader = {
   }
 };
 
-function getHubPositionInParentSpace(classMesh, parentObject) {
-  const hub = classMesh.getObjectByName('class-hub');
-  const worldPos = hub
-    ? hub.getWorldPosition(new THREE.Vector3())
-    : classMesh.getWorldPosition(new THREE.Vector3());
 
-  return parentObject ? parentObject.worldToLocal(worldPos.clone()) : worldPos;
+function getNodeHubs(node) {
+  return node?.userData?.hubs || null;
 }
+
+function getFallbackHub(node) {
+  return node?.userData?.linkHub || node?.getObjectByName('class-hub') || node;
+}
+
+function getHubWorldPosition(hub) {
+  return hub.getWorldPosition(new THREE.Vector3());
+}
+
+function chooseBestHubPair(sourceNode, targetNode) {
+  const sourceHubs = getNodeHubs(sourceNode);
+  const targetHubs = getNodeHubs(targetNode);
+  const sourceCandidates = sourceHubs ? Object.values(sourceHubs).filter(Boolean) : [getFallbackHub(sourceNode)];
+  const targetCandidates = targetHubs ? Object.values(targetHubs).filter(Boolean) : [getFallbackHub(targetNode)];
+  let best = { sourceHub: sourceCandidates[0], targetHub: targetCandidates[0], d2: Infinity };
+  for (const sHub of sourceCandidates) {
+    const s = getHubWorldPosition(sHub);
+    for (const tHub of targetCandidates) {
+      const t = getHubWorldPosition(tHub);
+      const d2 = s.distanceToSquared(t);
+      if (d2 < best.d2) best = { sourceHub: sHub, targetHub: tHub, d2 };
+    }
+  }
+  return best;
+}
+
+function getBestSourceHub(sourceNode, targetNode) {
+  return chooseBestHubPair(sourceNode, targetNode).sourceHub;
+}
+
+function getBestTargetHub(targetNode, sourceNode) {
+  return chooseBestHubPair(sourceNode, targetNode).targetHub;
+}
+
 
 function pathPoint(p0, p1, c, t) {
   const mt = 1 - t;
@@ -88,8 +118,12 @@ export function recalculateAllLinks() {
     const count = bucket.length;
     bucket.forEach((l, idx) => {
       const parent = l.linkGroup.parent;
-      const p0 = getHubPositionInParentSpace(l.sourceClass, parent);
-      const p1 = getHubPositionInParentSpace(l.targetClass, parent);
+      const sourceHub = getBestSourceHub(l.sourceClass, l.targetClass);
+      const targetHub = getBestTargetHub(l.targetClass, l.sourceClass);
+      const p0World = getHubWorldPosition(sourceHub);
+      const p1World = getHubWorldPosition(targetHub);
+      const p0 = parent ? parent.worldToLocal(p0World.clone()) : p0World;
+      const p1 = parent ? parent.worldToLocal(p1World.clone()) : p1World;
       const routePts = Array.isArray(l.linkData.rendering?.routePoints) ? l.linkData.rendering.routePoints : null;
       const points = [];
       let tangent = new THREE.Vector3(1, 0, 0);

--- a/js/hbds_hyperclass_class.js
+++ b/js/hbds_hyperclass_class.js
@@ -64,6 +64,21 @@ export function createHyperClass(scene, hyperClassData, options = {}) {
   hub.raycast = () => {};
   hyperMesh.add(hub);
 
+  const hubTop = hub.clone();
+  hubTop.position.set(0, sz.height / 2 - 0.16, 0.08);
+  const hubBottom = hub.clone();
+  hubBottom.position.set(0, -sz.height / 2 + 0.16, 0.08);
+  const hubLeft = hub.clone();
+  hubLeft.position.set(-sz.width / 2 + 0.16, 0, 0.08);
+  const hubRight = hub.clone();
+  hubRight.position.set(sz.width / 2 - 0.16, 0, 0.08);
+  const hubCenter = hub.clone();
+  hubCenter.position.set(0, 0, 0.08);
+  [hubTop, hubBottom, hubLeft, hubRight, hubCenter].forEach(h => { h.raycast = () => {}; hyperMesh.add(h); });
+  hyperMesh.userData.hubs = { top: hubTop, right: hubRight, bottom: hubBottom, left: hubLeft, center: hubCenter };
+  hyperMesh.userData.linkHub = hubCenter;
+
+
   hyperMesh.userData = {
     ...hyperMesh.userData,
     classId: hyperClassData.id,

--- a/js/hbds_model.js
+++ b/js/hbds_model.js
@@ -365,12 +365,24 @@ function lineIntersectsBox(start, end, rect) {
   return edges.some(([e1, e2]) => segmentsIntersect(start, end, e1, e2));
 }
 
+function getGridSpec(childCount) {
+  if (childCount <= 0) return { columns: 0, rows: 0 };
+  if (childCount === 1) return { columns: 1, rows: 1 };
+  if (childCount === 2) return { columns: 1, rows: 2 };
+  if (childCount === 3) return { columns: 1, rows: 3 };
+  if (childCount <= 6) return { columns: 2, rows: Math.ceil(childCount / 2) };
+  if (childCount <= 9) return { columns: 3, rows: Math.ceil(childCount / 3) };
+  if (childCount <= 16) return { columns: 4, rows: Math.ceil(childCount / 4) };
+  const columns = Math.ceil(Math.sqrt(childCount));
+  return { columns, rows: Math.ceil(childCount / columns) };
+}
+
 function layoutChildrenForAllHyperclasses(layout, options) { layout.nodes.filter(n => n.isHyperClass).forEach(h => layoutChildrenInsideHyperclass(h, layout, options)); }
 function layoutChildrenInsideHyperclass(hyperNode, layout, options) {
   const kids = layout.nodes.filter(n => n.parentClassId === hyperNode.id);
   hyperNode.contentBounds = computeHyperclassContentArea(hyperNode, options);
   if (!kids.length) return;
-  const cols = Math.ceil(Math.sqrt(kids.length)); const rows = Math.ceil(kids.length / cols);
+  const { columns: cols, rows } = getGridSpec(kids.length);
   const area = hyperNode.contentBounds;
   const cellW = (area.maxX - area.minX) / cols; const cellH = (area.maxY - area.minY) / rows;
   kids.forEach((k, i) => {


### PR DESCRIPTION
### Motivation

- Prevent links from attaching to borders/centers and ensure all link endpoints use visible hub anchors for accurate process-flow routing.
- Make child placement inside hyperclasses deterministic and follow the specified grid rules so nested layouts are predictable.
- Expose explicit hub metadata on nodes to support robust hub selection and future orthogonal routing improvements.

### Description

- Added multi-hub metadata (`userData.hubs` and `userData.linkHub`) to class and hyperclass meshes so nodes expose `top/right/bottom/left/center` hub objects (files modified: `js/hbds_class.js`, `js/hbds_hyperclass_class.js`).
- Introduced hub helper functions (`getNodeHubs`, `getFallbackHub`, `getHubWorldPosition`, `chooseBestHubPair`, `getBestSourceHub`, `getBestTargetHub`) and switched link endpoint selection to pick hub world positions instead of border/center points in `js/hbds_class_link.js`.
- Rewrote link recomputation to use the chosen hub world positions (converted to parent-local space) when building routes and arrow/label placement, so final link geometry originates from hubs.
- Added deterministic `getGridSpec(childCount)` and applied it to hyperclass child placement (`layoutChildrenInsideHyperclass`) so children follow the requested 1/2/3/4-column rules and predictable row/column layouts (file modified: `js/hbds_model.js`).

### Testing

- Ran static syntax checks with `node --check js/hbds_class_link.js`, `node --check js/hbds_class.js`, `node --check js/hbds_hyperclass_class.js`, and `node --check js/hbds_model.js`, all of which completed without errors.
- Performed a local layout rebuild and link recalculation via the existing `recalculateAllLinks()` path to validate hubs are resolved and routes are generated (no automated runtime tests failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff8e1e9aa4833186065a0b4ac2f80f)