### PR TITLE
Use a single red hub for classes and hyperclasses

### DIFF
--- a/js/hbds_class.js
+++ b/js/hbds_class.js
@@ -134,19 +134,7 @@ export function createClass(classData) {
     };
     classMesh.add(hub);
 
-    const hubTop = hub.clone();
-    hubTop.position.set(0, sz.height / 2 - 0.12, Z_OVERLAY);
-    const hubBottom = hub.clone();
-    hubBottom.position.set(0, -sz.height / 2 + 0.12, Z_OVERLAY);
-    const hubLeft = hub.clone();
-    hubLeft.position.set(-sz.width / 2 + 0.12, 0, Z_OVERLAY);
-    const hubRight = hub.clone();
-    hubRight.position.set(sz.width / 2 - 0.12, 0, Z_OVERLAY);
-    const hubCenter = hub.clone();
-    hubCenter.position.set(0, 0, Z_OVERLAY);
-    [hubTop, hubBottom, hubLeft, hubRight, hubCenter].forEach(h => { h.raycast = () => {}; classMesh.add(h); });
-    classMesh.userData.hubs = { top: hubTop, right: hubRight, bottom: hubBottom, left: hubLeft, center: hubCenter };
-    classMesh.userData.linkHub = hubCenter;
+    classMesh.userData.linkHub = hub;
 
     classMesh.add(titleObj);
     labels.push(titleObj);

--- a/js/hbds_hyperclass_class.js
+++ b/js/hbds_hyperclass_class.js
@@ -64,19 +64,7 @@ export function createHyperClass(scene, hyperClassData, options = {}) {
   hub.raycast = () => {};
   hyperMesh.add(hub);
 
-  const hubTop = hub.clone();
-  hubTop.position.set(0, sz.height / 2 - 0.16, 0.08);
-  const hubBottom = hub.clone();
-  hubBottom.position.set(0, -sz.height / 2 + 0.16, 0.08);
-  const hubLeft = hub.clone();
-  hubLeft.position.set(-sz.width / 2 + 0.16, 0, 0.08);
-  const hubRight = hub.clone();
-  hubRight.position.set(sz.width / 2 - 0.16, 0, 0.08);
-  const hubCenter = hub.clone();
-  hubCenter.position.set(0, 0, 0.08);
-  [hubTop, hubBottom, hubLeft, hubRight, hubCenter].forEach(h => { h.raycast = () => {}; hyperMesh.add(h); });
-  hyperMesh.userData.hubs = { top: hubTop, right: hubRight, bottom: hubBottom, left: hubLeft, center: hubCenter };
-  hyperMesh.userData.linkHub = hubCenter;
+  hyperMesh.userData.linkHub = hub;
 
 
   hyperMesh.userData = {


### PR DESCRIPTION
### Motivation
- Simplify node visuals and connection logic by having exactly one red hub per class/hyperclass instead of multiple directional clones.
- Ensure attribute lines and external links anchor to the same hub so routing remains consistent while reducing visual clutter.

### Description
- Removed the directional hub clones (`top`, `right`, `bottom`, `left`, `center`) and related `userData.hubs` population in `js/hbds_class.js`.  
- Removed the directional hub clones and `userData.hubs` population in `js/hbds_hyperclass_class.js`.  
- Set `userData.linkHub` to the single remaining red `class-hub` mesh in both `js/hbds_class.js` and `js/hbds_hyperclass_class.js` so links and attribute lines use the same anchor.  
- Kept attribute anchoring logic (`hubPos` usage and `attachAttributesToMesh`) intact so existing attribute wiring behavior is preserved.

### Testing
- Ran `git diff --check` and found no whitespace or diff issues (passed).  
- Created a commit with message `Simplify classes to a single red hub` (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff9b06787083319439f1c9deeb2542)