### PR TITLE
Fix overview drag interference with class/hyperclass dragging

### DIFF
--- a/js/hbds_model.js
+++ b/js/hbds_model.js
@@ -158,7 +158,10 @@ export function setupCanvasPanControls(context){
   let lastY = 0;
   host.addEventListener('pointerdown', (event) => {
     const is3D = document.getElementById('view-toggle')?.checked;
-    if (is3D || isPointerOverInteractiveObject(event, context)) return;
+    const inOverviewPanel = event.target instanceof Element
+      ? Boolean(event.target.closest('#model-overview'))
+      : false;
+    if (is3D || inOverviewPanel || isPointerOverInteractiveObject(event, context)) return;
     isPanning = true;
     lastX = event.clientX;
     lastY = event.clientY;


### PR DESCRIPTION
### Motivation
- Prevent the canvas pan handler from stealing pointer events that originate in the overview panel so dragging individual hyperclasses and classes is not preempted by canvas panning.

### Description
- In `setupCanvasPanControls` added a check that detects events originating inside `#model-overview` using `event.target.closest('#model-overview')` and skips starting pan when true, while preserving the existing 3D mode and interactive-object hit checks.

### Testing
- Performed quick smoke validation by inspecting the updated lines of `js/hbds_model.js` with `nl -ba js/hbds_model.js | sed -n '150,190p'` and committing the change with `git commit -m "Fix canvas pan handler from stealing overview interactions"`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00c9298e8c8331a2f3fcae8b3c76a1)