### PR TITLE
Allow self links by default in normalized link data

### DIFF
--- a/js/hbds_class_link.js
+++ b/js/hbds_class_link.js
@@ -187,5 +187,5 @@ export function updateLinkFontSizes(camera) {
 
 export function createLinkData(input={}, defaults={}){ return normalizeLinkData({ ...defaults, ...input, id: input.id ?? `link_${Math.random().toString(36).slice(2,8)}` }); }
 export function updateLinkData(linkData, patch={}){ return normalizeLinkData({ ...linkData, ...patch, rendering:{ ...(linkData.rendering||{}), ...(patch.rendering||{}) } }); }
-export function normalizeLinkData(linkData={}){ return { ...linkData, rendering:{ labelText: linkData.rendering?.labelText ?? linkData.id ?? '', ...(linkData.rendering||{}) } }; }
+export function normalizeLinkData(linkData={}){ return { ...linkData, allowSelfLink: linkData.allowSelfLink ?? true, rendering:{ labelText: linkData.rendering?.labelText ?? linkData.id ?? '', ...(linkData.rendering||{}) } }; }
 export function validateLinkData(linkData, classById){ const errors=[]; if(!linkData.sourceClassId) errors.push('missing sourceClassId'); if(!linkData.targetClassId) errors.push('missing targetClassId'); if(linkData.sourceClassId===linkData.targetClassId && !linkData.allowSelfLink) errors.push('self link not allowed'); if(classById){ if(!classById.has(linkData.sourceClassId)) errors.push('source not found'); if(!classById.has(linkData.targetClassId)) errors.push('target not found'); } return {valid:errors.length===0,errors,warnings:[]}; }


### PR DESCRIPTION
### Motivation
- Prevent runtime errors like `self link not allowed` when creating self-referential links by treating self-links as permitted unless explicitly disabled in `validateLinkData`.

### Description
- Set `allowSelfLink: linkData.allowSelfLink ?? true` inside `normalizeLinkData` in `js/hbds_class_link.js` so `createLink`/`createLinkData` will default to permitting self links.

### Testing
- Inspected references with `rg` and the file with `sed`, reviewed the diff with `git diff`, and committed the change with `git commit`, all of which succeeded; no automated unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d3c9dff48331958c3f78ef67ffb8)