### PR TITLE
feat: add interactive HBDS diagram editor controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -137,3 +137,21 @@ select {
   background: rgba(255, 51, 0, 0.08);
   pointer-events: none;
 }
+
+.editor-tools button,
+.editor-tools input[type="file"] {
+  width: 100%;
+  padding: 8px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: #fff;
+}
+
+#selection-info {
+  font-size: 12px;
+  color: #333;
+  padding: 6px;
+  background: #f6f7f8;
+  border: 1px solid #e1e4e8;
+  border-radius: 4px;
+}

--- a/index.html
+++ b/index.html
@@ -45,6 +45,16 @@
     <div class="control-group">
         <button id="fit-model-button">Fit Model</button>
     </div>
+    <div class="control-group editor-tools">
+        <label>Diagram Editor</label>
+        <button id="add-class-button">Add Class</button>
+        <button id="add-hyperclass-button">Add Hyperclass</button>
+        <button id="delete-selected-button">Delete Selected</button>
+        <button id="add-link-button">Link Selected Pair</button>
+        <button id="export-json-button">Export JSON</button>
+        <input id="import-json-input" type="file" accept="application/json">
+        <div id="selection-info">Selected: none</div>
+    </div>
 </div>
 <script type="importmap">
     {
@@ -65,7 +75,7 @@
     import {updateLabelFontSizes as updateHyperClassLabelFontSizes} from './js/hbds_hyperclass_class.js';
     import { updateLinkFontSizes, recalculateAllLinks } from './js/hbds_class_link.js';
     import { updateLinkFontSizes as updateHyperClassLinkFontSizes } from './js/hbds_hyperclass_link.js';
-    import { loadAndRenderScene, saveScene, optimizeAndRefreshLayout, fitModelToCanvas, initModelOverview, updateModelOverview, setupCanvasPanControls } from './js/hbds_model.js';
+    import { loadAndRenderScene, saveScene, optimizeAndRefreshLayout, fitModelToCanvas, initModelOverview, updateModelOverview, setupCanvasPanControls, getData, createClass, createHyperclass, deleteClass, createLink, setData } from './js/hbds_model.js';
 
     /* ---------- Globals ---------- */
     let scene, camera, renderer, css2DRenderer, orbitControls, dragControls;
@@ -129,6 +139,77 @@
             fitModelToCanvas(getModelContext(), { padding: 1.15, updateOverview: true });
         });
         document.getElementById('fit-model-button').addEventListener('click', () => {
+            fitModelToCanvas(getModelContext(), { padding: 1.15, updateOverview: true });
+        });
+
+        let selectedNodeIds = [];
+        const selectionInfo = document.getElementById('selection-info');
+        const setSelection = (ids) => {
+            selectedNodeIds = ids;
+            selectionInfo.textContent = `Selected: ${ids.length ? ids.join(', ') : 'none'}`;
+        };
+
+        const pickClassRoot = (object) => {
+            let cursor = object;
+            while (cursor) {
+                if (cursor.userData?.hbdsId) return cursor;
+                cursor = cursor.parent;
+            }
+            return null;
+        };
+
+        css2DRenderer.domElement.addEventListener('pointerdown', (event) => {
+            const rect = renderer.domElement.getBoundingClientRect();
+            const pointer = new THREE.Vector2(
+                ((event.clientX - rect.left) / rect.width) * 2 - 1,
+                -((event.clientY - rect.top) / rect.height) * 2 + 1
+            );
+            const raycaster = new THREE.Raycaster();
+            raycaster.setFromCamera(pointer, camera);
+            const hits = raycaster.intersectObjects(diagramGroup.children, true);
+            const hit = hits.find(h => pickClassRoot(h.object));
+            if (!hit) return;
+            const picked = pickClassRoot(hit.object);
+            const id = picked.userData.hbdsId;
+            if (event.shiftKey) {
+                const next = selectedNodeIds.includes(id)
+                    ? selectedNodeIds.filter(v => v !== id)
+                    : [...selectedNodeIds, id].slice(-2);
+                setSelection(next);
+            } else {
+                setSelection([id]);
+            }
+        });
+
+        document.getElementById('add-class-button').addEventListener('click', () => {
+            const node = createClass({ name: `Class ${getData().hypergraph.class.length + 1}` }, { context: getModelContext() });
+            setSelection([node.id]);
+            fitModelToCanvas(getModelContext(), { padding: 1.15, updateOverview: true });
+        });
+        document.getElementById('add-hyperclass-button').addEventListener('click', () => {
+            const node = createHyperclass({ name: `Hyperclass ${getData().hypergraph.class.length + 1}` }, { context: getModelContext() });
+            setSelection([node.id]);
+            fitModelToCanvas(getModelContext(), { padding: 1.15, updateOverview: true });
+        });
+        document.getElementById('delete-selected-button').addEventListener('click', () => {
+            selectedNodeIds.forEach(id => deleteClass(id, { context: getModelContext() }));
+            setSelection([]);
+            fitModelToCanvas(getModelContext(), { padding: 1.15, updateOverview: true });
+        });
+        document.getElementById('add-link-button').addEventListener('click', () => {
+            if (selectedNodeIds.length !== 2) return;
+            createLink({ sourceClassId: selectedNodeIds[0], targetClassId: selectedNodeIds[1], label: 'relation' }, { context: getModelContext() });
+            fitModelToCanvas(getModelContext(), { padding: 1.15, updateOverview: true });
+        });
+        document.getElementById('export-json-button').addEventListener('click', () => {
+            saveScene(getModelContext(), { fileName: 'hbds_editor_export.json' });
+        });
+        document.getElementById('import-json-input').addEventListener('change', async (event) => {
+            const file = event.target.files?.[0];
+            if (!file) return;
+            const parsed = JSON.parse(await file.text());
+            setData(parsed, { context: getModelContext(), refresh: true });
+            setSelection([]);
             fitModelToCanvas(getModelContext(), { padding: 1.15, updateOverview: true });
         });
 


### PR DESCRIPTION
### Motivation
- Provide in-UI editing workflows so users can create, delete, link, import, and export HBDS nodes without leaving the simulator.
- Reuse existing model mutation APIs to keep rendering and data mutation consistent with the current scene pipeline.

### Description
- Added a new "Diagram Editor" control block in `index.html` with buttons for `Add Class`, `Add Hyperclass`, `Delete Selected`, `Link Selected Pair`, `Export JSON`, and a file input for `Import JSON` and a selection status display.
- Imported and wired model APIs from `js/hbds_model.js` (`getData`, `createClass`, `createHyperclass`, `deleteClass`, `createLink`, `setData`) and implemented pointer-based selection using raycasting on `css2DRenderer.domElement` supporting single-click and Shift multi-select (up to two IDs).
- Hooked editor actions to existing model mutation functions and scene refresh flows and call `fitModelToCanvas` after edits to keep the view focused on changes.
- Added UI styling for the new editor controls in `css/style.css` to match the existing control panel look and feel.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00d62080848331a0447495770825ab)