### PR TITLE
Isolate DragControls to active object and add deterministic hyperclass grid layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -168,6 +168,7 @@
         dragControls.transformGroup = false;
         let selectedObject = null;
         let selectedOrder = 1;
+        let dragObjectsBackup = null;
 
         const setObjectRenderOrder = (object, order) => {
             object.traverse?.(child => {
@@ -178,6 +179,8 @@
         };
 
         dragControls.addEventListener('dragstart', ev => {
+            dragObjectsBackup = dragControls.objects.slice();
+            dragControls.objects = [ev.object];
             if (selectedObject && selectedObject !== ev.object) {
                 setObjectRenderOrder(selectedObject, 1);
             }
@@ -202,6 +205,7 @@
         });
 
         dragControls.addEventListener('dragend', ev => {
+            if (dragObjectsBackup) dragControls.objects = dragObjectsBackup;
             if (ev.object?.userData) {
                 delete ev.object.userData.dragStartZ;
             }

--- a/js/hbds_model.js
+++ b/js/hbds_model.js
@@ -7,6 +7,10 @@ import { createLinkBetweenHyperClass, updateLinkFontSizes as updateHyperClassLin
 let data = { hypergraph: { class: [], link: [] } };
 const history=[];
 const modelRuntime={ classById:new Map(), linkGroups:[], diagramGroup:null, draggableObjects:[] };
+const GRID_GAP_X = 0.9;
+const GRID_GAP_Y = 0.9;
+const ROOT_GAP_X = 2.6;
+const ROOT_GAP_Y = 2.2;
 const clone=(v)=>typeof structuredClone==='function'?structuredClone(v):JSON.parse(JSON.stringify(v));
 const nextId=(p)=>`${p}_${Math.random().toString(36).slice(2,8)}`;
 export const getData=()=>data;
@@ -267,4 +271,68 @@ export const updateLink=(idOrPred,patch,options={})=>commitDataChange('updateLin
 export const deleteLink=(idOrPred,options={})=>commitDataChange('deleteLink',d=>{d.hypergraph.link=d.hypergraph.link.filter(l=>!(typeof idOrPred==='function'?idOrPred(l):l.id===idOrPred||(idOrPred?.sourceClassId===l.sourceClassId&&idOrPred?.targetClassId===l.targetClassId)));},options);
 export async function loadAndRenderScene(modelName, context){ const raw=await HyperClassLoader.load(modelName).catch(()=>ClassLoader.load(modelName)); setData(raw,{context,refresh:true}); return getData(); }
 export function saveScene(context, options={}){ const blob=new Blob([JSON.stringify(getData(),null,2)],{type:'application/json'}); const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download=options.fileName||'hbds_saved_model.json'; a.click(); URL.revokeObjectURL(url); return getData(); }
-export async function optimizeAndRefreshLayout(context, options={}){ refreshSceneFromData(context); updateLayoutFromData(context,options); }
+function getNodeSize(node){
+  const base=node?.size||{};
+  const attrCount=Array.isArray(node?.attributes)?node.attributes.length:0;
+  const minH=node?.type==='hyperclass'?3.2:2;
+  const width=Math.max(base.width||1, node?.type==='hyperclass'?4:1);
+  const height=Math.max(base.height||minH, minH + attrCount*0.18);
+  return { width, height };
+}
+function getGridDimensions(childCount){
+  if(childCount<=1) return {cols:1,rows:1};
+  if(childCount===2) return {cols:1,rows:2};
+  if(childCount===3) return {cols:1,rows:3};
+  if(childCount===4) return {cols:2,rows:2};
+  if(childCount<=6) return {cols:2,rows:Math.ceil(childCount/2)};
+  if(childCount<=9) return {cols:3,rows:Math.ceil(childCount/3)};
+  if(childCount<=16) return {cols:4,rows:Math.ceil(childCount/4)};
+  const cols=Math.ceil(Math.sqrt(childCount));
+  return {cols,rows:Math.ceil(childCount/cols)};
+}
+function optimizeLayoutData(){
+  const nodes=data.hypergraph.class||[];
+  const byId=new Map(nodes.map(n=>[n.id,n]));
+  const childrenByParent=new Map();
+  nodes.forEach(n=>{ if(n.parentClassId){ const a=childrenByParent.get(n.parentClassId)||[]; a.push(n); childrenByParent.set(n.parentClassId,a); } });
+  const roots=nodes.filter(n=>!n.parentClassId).sort((a,b)=>String(a.name).localeCompare(String(b.name)));
+
+  function layoutNode(node, cx, cy){
+    const kids=(childrenByParent.get(node.id)||[]).sort((a,b)=>String(a.name).localeCompare(String(b.name)));
+    const own=getNodeSize(node);
+    if(!node.position) node.position={x:0,y:0,z:0};
+    node.position.x=cx; node.position.y=cy; node.position.z=0;
+    if(node.type!=='hyperclass' || kids.length===0) return own;
+
+    const {cols,rows}=getGridDimensions(kids.length);
+    const childSizes=kids.map(getNodeSize);
+    const cellW=Math.max(...childSizes.map(s=>s.width))+GRID_GAP_X;
+    const cellH=Math.max(...childSizes.map(s=>s.height))+GRID_GAP_Y;
+    const gridW=Math.max(cellW*cols, own.width-1.2);
+    const gridH=Math.max(cellH*rows, own.height-1.2);
+    node.size={width:Math.max(own.width,gridW+1.2),height:Math.max(own.height,gridH+1.2)};
+
+    const startX=cx-gridW/2+cellW/2;
+    const startY=cy+gridH/2-cellH/2;
+    kids.forEach((child, idx)=>{
+      const col=idx%cols;
+      const row=Math.floor(idx/cols);
+      const x=startX + col*cellW;
+      const y=startY - row*cellH;
+      layoutNode(child,x,y);
+    });
+    return node.size;
+  }
+
+  const rootCount=roots.length;
+  const rootCols=Math.max(1,Math.ceil(Math.sqrt(rootCount)));
+  const rootRows=Math.ceil(rootCount/rootCols);
+  roots.forEach((root,idx)=>{
+    const col=idx%rootCols;
+    const row=Math.floor(idx/rootCols);
+    const x=(col-(rootCols-1)/2)*(6+ROOT_GAP_X);
+    const y=((rootRows-1)/2-row)*(5+ROOT_GAP_Y);
+    layoutNode(root,x,y);
+  });
+}
+export async function optimizeAndRefreshLayout(context, options={}){ optimizeLayoutData(); refreshSceneFromData(context); updateLayoutFromData(context,options); }

--- a/js/test_dynamic_hbds_layout.js
+++ b/js/test_dynamic_hbds_layout.js
@@ -26,7 +26,7 @@ function ensureLighting(){
   fill.position.set(-10,-6,8);
   scene.add(fill);
 }
-function setupDrag(){ if(dragControls) dragControls.dispose(); dragControls=new DragControls(draggableObjects,camera,labelRenderer.domElement); dragControls.addEventListener('dragstart',()=>orbitControls.enabled=false); dragControls.addEventListener('dragend',()=>{orbitControls.enabled=true; updateJsonPreviewFromData();}); }
+function setupDrag(){ if(dragControls) dragControls.dispose(); dragControls=new DragControls(draggableObjects,camera,labelRenderer.domElement); let dragObjectsBackup=null; dragControls.addEventListener('dragstart',(ev)=>{dragObjectsBackup=dragControls.objects.slice(); dragControls.objects=[ev.object]; orbitControls.enabled=false;}); dragControls.addEventListener('dragend',()=>{if(dragObjectsBackup) dragControls.objects=dragObjectsBackup; orbitControls.enabled=true; updateJsonPreviewFromData();}); }
 async function afterCrud(){
   if(shouldOptimizeAfterCrud()) await optimizeAndRefreshLayout(ctx());
   else refreshSceneFromData(ctx());


### PR DESCRIPTION
### Motivation
- Prevent multiple selected/nearby nodes from moving together during a drag gesture by making drag behavior operate only on the actively dragged object. 
- Provide a deterministic, visually balanced layout optimizer that arranges hyperclasses and their children in a grid consistent with the requested child-count rules and prevents overlaps.

### Description
- Limit drag targets during a drag: temporarily store `dragControls.objects`, set `dragControls.objects = [ev.object]` on `dragstart`, and restore the original list on `dragend`, with the change applied in `index.html` and the test harness `js/test_dynamic_hbds_layout.js`.
- Implement deterministic layout routines in `js/hbds_model.js` by adding constants `GRID_GAP_X`, `GRID_GAP_Y`, `ROOT_GAP_X`, `ROOT_GAP_Y` and new helper functions `getNodeSize`, `getGridDimensions`, and `optimizeLayoutData` to compute node sizes and place children using the requested grid rules (1,2,3,4,5-6,7-9,10-16,>16 near-square) with row-major fill and name-sorted ordering.
- Resize hyperclass bounding sizes to contain children and attributes and place root-level nodes in a near-square, balanced arrangement before refreshing the scene; `optimizeAndRefreshLayout` now calls `optimizeLayoutData()` then refresh/update routines.
- Files changed: `index.html`, `js/test_dynamic_hbds_layout.js`, and `js/hbds_model.js`.

### Testing
- Automated tests: none executed (no test suite was run by the patch process).
- Development smoke: the patch applied and the code changes were committed cleanly (syntactic/basic integration checks performed during the edit/commit steps).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00e3dcb4648331b83b681e3cda354f)