### PR TITLE
Fix drag interactions and improve self-link and label rendering

### DIFF
--- a/js/hbds_class_link.js
+++ b/js/hbds_class_link.js
@@ -92,8 +92,11 @@ export function createLinkBetweenClass(linkData, classById) {
   labelDiv.style.font = `${rendering.labelFontSize ?? 12}px Arial`;
   labelDiv.style.color = rendering.labelColor ?? '#111111';
   labelDiv.style.background = rendering.labelBackgroundColor ?? 'rgba(255,255,255,0.9)';
-  labelDiv.style.padding = '1px 4px';
-  labelDiv.style.borderRadius = '3px';
+  labelDiv.style.padding = '2px 8px';
+  labelDiv.style.borderRadius = '999px';
+  labelDiv.style.border = '1px solid rgba(55,65,81,0.45)';
+  labelDiv.style.whiteSpace = 'nowrap';
+  labelDiv.style.textAlign = 'center';
   const labelObj = new CSS2DObject(labelDiv);
   linkLabels.push(labelObj);
 
@@ -139,6 +142,28 @@ export function recalculateAllLinks() {
         l.arrow.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), tangent);
         const labelIndex = Math.max(1, Math.floor((points.length - 1) * (l.linkData.rendering?.labelPositionAlongPath ?? 0.5)));
         lp = points[labelIndex].clone();
+      } else if (l.linkData.sourceClassId === l.linkData.targetClassId) {
+        const loopRadius = l.linkData.rendering?.selfLoopRadius ?? 0.75;
+        const loopLift = l.linkData.rendering?.selfLoopLift ?? 0.85;
+        const center = p0.clone().add(new THREE.Vector3(loopRadius, loopLift, 0));
+        const seg = 56;
+        for (let i = 0; i <= seg; i++) {
+          const a = (Math.PI * 2 * i) / seg;
+          points.push(new THREE.Vector3(
+            center.x + loopRadius * Math.cos(a),
+            center.y + loopRadius * Math.sin(a),
+            p0.z
+          ));
+        }
+        l.line.geometry.setFromPoints(points);
+        l.line.computeLineDistances();
+        const arrowIdx = Math.floor(seg * 0.92);
+        const arrowPos = points[arrowIdx].clone();
+        const prev = points[Math.max(arrowIdx - 1, 0)].clone();
+        tangent = arrowPos.clone().sub(prev).normalize();
+        l.arrow.position.copy(arrowPos);
+        l.arrow.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), tangent);
+        lp = center.clone().add(new THREE.Vector3(0, 0, 0));
       } else {
         const mid = new THREE.Vector3().addVectors(p0, p1).multiplyScalar(0.5);
         const dir = new THREE.Vector3().subVectors(p1, p0);

--- a/js/test_dynamic_hbds_layout.js
+++ b/js/test_dynamic_hbds_layout.js
@@ -26,7 +26,7 @@ function ensureLighting(){
   fill.position.set(-10,-6,8);
   scene.add(fill);
 }
-function setupDrag(){ if(dragControls) dragControls.dispose(); dragControls=new DragControls(draggableObjects,camera,labelRenderer.domElement); let dragObjectsBackup=null; dragControls.addEventListener('dragstart',(ev)=>{dragObjectsBackup=dragControls.objects.slice(); dragControls.objects=[ev.object]; orbitControls.enabled=false;}); dragControls.addEventListener('dragend',()=>{if(dragObjectsBackup) dragControls.objects=dragObjectsBackup; orbitControls.enabled=true; updateJsonPreviewFromData();}); }
+function setupDrag(){ if(dragControls) dragControls.dispose(); dragControls=new DragControls(draggableObjects,camera,renderer.domElement); let dragObjectsBackup=null; dragControls.addEventListener('dragstart',(ev)=>{dragObjectsBackup=dragControls.objects.slice(); dragControls.objects=[ev.object]; orbitControls.enabled=false;}); dragControls.addEventListener('dragend',()=>{if(dragObjectsBackup) dragControls.objects=dragObjectsBackup; orbitControls.enabled=true; updateJsonPreviewFromData();}); }
 async function afterCrud(){
   if(shouldOptimizeAfterCrud()) await optimizeAndRefreshLayout(ctx());
   else refreshSceneFromData(ctx());


### PR DESCRIPTION
### Motivation
- Users could not reliably drag class/hyperclass nodes from `test_dynamic_hbds_layout.html` because pointer events were being attached to the CSS label layer instead of the WebGL canvas. 
- Self-links (where a link’s source equals its target) were not rendered as distinct loops and could overlap other elements and labels. 
- Link labels needed a clearer visual treatment to avoid overlap and improve readability.

### Description
- Changed `DragControls` instantiation in `js/test_dynamic_hbds_layout.js` to use `renderer.domElement` so drag pointer events are received by the WebGL canvas instead of the CSS label layer. 
- Updated link label styling in `js/hbds_class_link.js` to a rounded pill with `padding`, `borderRadius`, `border`, `whiteSpace: nowrap`, and centered text for improved readability. 
- Added explicit self-link rendering in `js/hbds_class_link.js` (branch when `sourceClassId === targetClassId`) that generates a circular loop path, positions and orients the arrowhead consistently, and centers the label over the loop; defaults `selfLoopRadius` and `selfLoopLift` are supported via `rendering` options. 
- Kept existing multi-link offset and routed-path behavior intact and integrated self-loop handling into `recalculateAllLinks` so labels, arrows, and line geometry are updated consistently.

### Testing
- Ran `node --check js/test_dynamic_hbds_layout.js` and it completed without syntax errors. 
- Ran `node --check js/hbds_class_link.js` and it completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00f69237508331b23e78b08c723633)