### PR TITLE
Diagram editor: self-link rendering, attribute layout, editable mode, and overview panning

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,12 @@
         </label>
     </div>
     <div class="control-group">
+        <label class="checkbox-wrapper" for="editable-toggle">
+            <input type="checkbox" id="editable-toggle" checked>
+            <span>Editable mode</span>
+        </label>
+    </div>
+    <div class="control-group">
         <button id="save-model-button">Save Model</button>
     </div>
     <div class="control-group">
@@ -131,6 +137,7 @@
         document.getElementById('fit-model-button').addEventListener('click', () => {
             fitModelToCanvas(getModelContext(), { padding: 1.15, updateOverview: true });
         });
+        document.getElementById('editable-toggle').addEventListener('change', toggleEditableMode);
 
         setupCanvasPanControls(getModelContext());
         initModelOverview(getModelContext());
@@ -238,6 +245,11 @@
         if (dragControls) dragControls.enabled = !is3D;
         if (!is3D) setCamera2D();
         updateModelOverview(getModelContext());
+    }
+    function toggleEditableMode(e) {
+        const editable = e.target.checked;
+        if (dragControls) dragControls.enabled = editable && !document.getElementById('view-toggle').checked;
+        orbitControls.enabled = !editable;
     }
 
     function setCamera2D() {

--- a/js/hbds_class.js
+++ b/js/hbds_class.js
@@ -163,12 +163,22 @@ export function attachAttributesToMesh(classMesh, attributes, options = {}) {
     const cbH = attrCfg.size.height ?? cbW;
     const gapY = options.gapY ?? 0.15;
     const startY = options.startY ?? (size.height / 2 - 0.1);
-    const colX = options.colX ?? (size.width / 2 + 0.25 + cbW);
+    const insideBounds = options.insideBounds === true;
+    const colX = options.colX ?? (insideBounds ? (size.width / 2 - 0.4 - cbW) : (size.width / 2 + 0.25 + cbW));
     const hubPos = options.hubPosition ?? new THREE.Vector3((size.width * 0.9) / 2, (size.height * 0.9) / 2, options.z ?? 0.06);
     const z = options.z ?? 0.06;
 
+    const minX = -size.width / 2 + 0.18;
+    const maxX = size.width / 2 - 0.18;
+    const minY = -size.height / 2 + 0.2;
+    const maxY = size.height / 2 - 0.2;
+    const maxRows = Math.max(1, Math.floor((maxY - minY) / gapY));
+
     attributes.forEach((attrName, idx) => {
-        const y = startY - idx * gapY;
+        const col = insideBounds ? Math.floor(idx / maxRows) : 0;
+        const row = insideBounds ? (idx % maxRows) : idx;
+        const y = THREE.MathUtils.clamp(startY - row * gapY, minY, maxY);
+        const x = THREE.MathUtils.clamp(colX - col * (cbW + 0.22), minX, maxX);
 
         // checkbox cube
         const cube = new THREE.Mesh(
@@ -179,7 +189,7 @@ export function attachAttributesToMesh(classMesh, attributes, options = {}) {
                 roughness: 0.25
             })
         );
-        cube.position.set(colX, y, z);
+        cube.position.set(x, y, z);
         cube.raycast = () => {
         };
         classMesh.add(cube);
@@ -203,8 +213,9 @@ export function attachAttributesToMesh(classMesh, attributes, options = {}) {
         aDiv.style.font = '12px Arial';
         aDiv.textContent = attrName;
         const aLbl = new CSS2DObject(aDiv);
-        aLbl.position.set(colX + cbW + 0.12, y, z);
-        aLbl.center.set(0, 0.5);
+        const labelX = insideBounds ? x - cbW - 0.05 : x + cbW + 0.12;
+        aLbl.position.set(THREE.MathUtils.clamp(labelX, minX, maxX), y, z);
+        aLbl.center.set(insideBounds ? 1 : 0, 0.5);
         classMesh.add(aLbl);
         labels.push(aLbl);
     });

--- a/js/hbds_class_link.js
+++ b/js/hbds_class_link.js
@@ -121,8 +121,9 @@ export function recalculateAllLinks() {
     const count = bucket.length;
     bucket.forEach((l, idx) => {
       const parent = l.linkGroup.parent;
-      const sourceHub = getBestSourceHub(l.sourceClass, l.targetClass);
-      const targetHub = getBestTargetHub(l.targetClass, l.sourceClass);
+      const isSelfLink = l.linkData.sourceClassId === l.linkData.targetClassId;
+      const sourceHub = isSelfLink ? getFallbackHub(l.sourceClass) : getBestSourceHub(l.sourceClass, l.targetClass);
+      const targetHub = isSelfLink ? getFallbackHub(l.targetClass) : getBestTargetHub(l.targetClass, l.sourceClass);
       const p0World = getHubWorldPosition(sourceHub);
       const p1World = getHubWorldPosition(targetHub);
       const p0 = parent ? parent.worldToLocal(p0World.clone()) : p0World;
@@ -142,28 +143,24 @@ export function recalculateAllLinks() {
         l.arrow.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), tangent);
         const labelIndex = Math.max(1, Math.floor((points.length - 1) * (l.linkData.rendering?.labelPositionAlongPath ?? 0.5)));
         lp = points[labelIndex].clone();
-      } else if (l.linkData.sourceClassId === l.linkData.targetClassId) {
-        const loopRadius = l.linkData.rendering?.selfLoopRadius ?? 0.75;
-        const loopLift = l.linkData.rendering?.selfLoopLift ?? 0.85;
-        const center = p0.clone().add(new THREE.Vector3(loopRadius, loopLift, 0));
-        const seg = 56;
-        for (let i = 0; i <= seg; i++) {
-          const a = (Math.PI * 2 * i) / seg;
-          points.push(new THREE.Vector3(
-            center.x + loopRadius * Math.cos(a),
-            center.y + loopRadius * Math.sin(a),
-            p0.z
-          ));
-        }
+      } else if (isSelfLink) {
+        const selfNormal = new THREE.Vector3(1, 1, 0).normalize();
+        const selfLength = l.linkData.rendering?.selfLinkLength ?? 0.95;
+        const end = p0.clone().addScaledVector(selfNormal, selfLength);
+        const mid = p0.clone().add(end).multiplyScalar(0.5);
+        const ortho = new THREE.Vector3(-selfNormal.y, selfNormal.x, 0).normalize();
+        const control = mid.clone().addScaledVector(ortho, l.linkData.rendering?.curveOffset ?? 0.35);
+        const seg = 24;
+        for (let i = 0; i <= seg; i++) points.push(pathPoint(p0, end, control, i / seg));
         l.line.geometry.setFromPoints(points);
         l.line.computeLineDistances();
-        const arrowIdx = Math.floor(seg * 0.92);
-        const arrowPos = points[arrowIdx].clone();
-        const prev = points[Math.max(arrowIdx - 1, 0)].clone();
+        const arrowT = 0.92;
+        const arrowPos = pathPoint(p0, end, control, arrowT);
+        const prev = pathPoint(p0, end, control, arrowT - 0.05);
         tangent = arrowPos.clone().sub(prev).normalize();
         l.arrow.position.copy(arrowPos);
         l.arrow.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), tangent);
-        lp = center.clone().add(new THREE.Vector3(0, 0, 0));
+        lp = pathPoint(p0, end, control, l.linkData.rendering?.labelPositionAlongPath ?? 0.55);
       } else {
         const mid = new THREE.Vector3().addVectors(p0, p1).multiplyScalar(0.5);
         const dir = new THREE.Vector3().subVectors(p1, p0);

--- a/js/hbds_hyperclass_class.js
+++ b/js/hbds_hyperclass_class.js
@@ -95,9 +95,10 @@ export function createHyperClass(scene, hyperClassData, options = {}) {
       lineWidth: hyperClassData.rendering?.connections?.lineWidth ?? 0.01
     },
     textColor,
-    startY: sz.height / 2 - 0.45,
+    startY: sz.height / 2 - 0.55,
     gapY: 0.16,
-    colX: sz.width / 2 + 0.28,
+    colX: sz.width / 2 - 0.35,
+    insideBounds: true,
     hubPosition: hub.position.clone(),
     z: 0.08
   });

--- a/js/hbds_model.js
+++ b/js/hbds_model.js
@@ -167,7 +167,10 @@ export function setupCanvasPanControls(context){
     const inOverviewPanel = event.target instanceof Element
       ? Boolean(event.target.closest('#model-overview'))
       : false;
-    if (is3D || inOverviewPanel || isPointerOverInteractiveObject(event, context)) return;
+    const editable = document.getElementById('editable-toggle')?.checked ?? true;
+    if (is3D || inOverviewPanel) return;
+    if (editable && isPointerOverInteractiveObject(event, context)) return;
+    if (editable) return;
     isPanning = true;
     lastX = event.clientX;
     lastY = event.clientY;
@@ -246,6 +249,46 @@ export function updateOverviewViewport(context, transform) {
   viewport.style.top = `${Math.min(p1.y, p2.y)}px`;
   viewport.style.width = `${Math.abs(p2.x - p1.x)}px`;
   viewport.style.height = `${Math.abs(p2.y - p1.y)}px`;
+  setupOverviewViewportDrag(context, transform);
+}
+let overviewDragBound = false;
+function overviewToWorld(x, y, transform, canvas) {
+  const worldX = transform.min.x + (x - transform.pad) / transform.scale;
+  const worldY = transform.min.y + ((canvas.height - y) - transform.pad) / transform.scale;
+  return { x: worldX, y: worldY };
+}
+function setupOverviewViewportDrag(context, transform) {
+  if (overviewDragBound) return;
+  const viewport = document.getElementById('model-overview-viewport');
+  const canvas = document.getElementById('model-overview-canvas');
+  if (!viewport || !canvas) return;
+  let dragging = false;
+  viewport.addEventListener('pointerdown', (e) => {
+    dragging = true;
+    viewport.setPointerCapture?.(e.pointerId);
+  });
+  viewport.addEventListener('pointermove', (e) => {
+    if (!dragging || !context?.camera || !context?.orbitControls) return;
+    const rect = canvas.getBoundingClientRect();
+    const cx = e.clientX - rect.left;
+    const cy = e.clientY - rect.top;
+    const world = overviewToWorld(cx, cy, getOverviewTransform(context, canvas), canvas);
+    const dx = world.x - context.orbitControls.target.x;
+    const dy = world.y - context.orbitControls.target.y;
+    context.orbitControls.target.set(world.x, world.y, context.orbitControls.target.z);
+    context.camera.position.x += dx;
+    context.camera.position.y += dy;
+    context.orbitControls.update();
+    context.renderOnce?.();
+    updateModelOverview(context);
+  });
+  const stop = (e) => {
+    dragging = false;
+    viewport.releasePointerCapture?.(e.pointerId);
+  };
+  viewport.addEventListener('pointerup', stop);
+  viewport.addEventListener('pointercancel', stop);
+  overviewDragBound = true;
 }
 export function commitDataChange(operationName, updater, options={}){ const before=clone(data); const result=updater(data); data=normalizeData(data); const v=validateData(data); if(!v.valid && options.rollbackOnError!==false){ data=before; throw new Error(`Invalid data after ${operationName}: ${v.errors.join('; ')}`);} if(options.refresh!==false) refreshSceneFromData(options.context); if(options.optimizeLayout===true) updateLayoutFromData(options.context); if(options.saveHistory!==false) history.push({operationName,before,after:clone(data)}); return result; }
 export function setData(nextData, options={}){ data=normalizeData(nextData); const v=validateData(data); if(!v.valid) throw new Error(v.errors.join('; ')); if(options.refresh!==false) refreshSceneFromData(options.context); return getData(); }
@@ -275,8 +318,10 @@ function getNodeSize(node){
   const base=node?.size||{};
   const attrCount=Array.isArray(node?.attributes)?node.attributes.length:0;
   const minH=node?.type==='hyperclass'?3.2:2;
-  const width=Math.max(base.width||1, node?.type==='hyperclass'?4:1);
-  const height=Math.max(base.height||minH, minH + attrCount*0.18);
+  const minW=node?.type==='hyperclass'?4:1;
+  const attrW=node?.type==='hyperclass' ? 3.2 : 1.2;
+  const width=Math.max(base.width||1, minW, attrW);
+  const height=Math.max(base.height||minH, minH + attrCount*0.2);
   return { width, height };
 }
 function getGridDimensions(childCount){
@@ -308,9 +353,13 @@ function optimizeLayoutData(){
     const childSizes=kids.map(getNodeSize);
     const cellW=Math.max(...childSizes.map(s=>s.width))+GRID_GAP_X;
     const cellH=Math.max(...childSizes.map(s=>s.height))+GRID_GAP_Y;
-    const gridW=Math.max(cellW*cols, own.width-1.2);
-    const gridH=Math.max(cellH*rows, own.height-1.2);
-    node.size={width:Math.max(own.width,gridW+1.2),height:Math.max(own.height,gridH+1.2)};
+    const padX = 1.2;
+    const padY = 1.1;
+    const gridW=Math.max(cellW*cols, own.width-padX);
+    const gridH=Math.max(cellH*rows, own.height-padY);
+    const attrRows=Math.max(1,Math.ceil((Array.isArray(node.attributes)?node.attributes.length:0)/Math.max(1,Math.floor((gridH)/0.16))));
+    const attrPadX = attrRows > 1 ? 0.8 : 0.5;
+    node.size={width:Math.max(own.width,gridW+padX+attrPadX),height:Math.max(own.height,gridH+padY)};
 
     const startX=cx-gridW/2+cellW/2;
     const startY=cy+gridH/2-cellH/2;


### PR DESCRIPTION
### Motivation
- Improve visual and interaction behavior of the diagram editor so links, hyperclasses, and attributes render and interact in a way that matches UX expectations (self-links should look like normal links and attributes should stay inside hyperclass bounds).
- Provide an editable mode toggle so authors can switch between panning the canvas and dragging individual class/hyperclass nodes.
- Make the overview pane a faithful miniature of the diagram and allow dragging its viewport to pan the main canvas.

### Description
- Render self-links as normal curved segments anchored to the node red hub instead of circular loops by updating the link routing in `js/hbds_class_link.js` and preferring the class/hyperclass `linkHub` for self-links. (`recalculateAllLinks` changed to detect `isSelfLink` and build a curved path`).
- Add in-bounds attribute placement and clamp logic in `js/hbds_class.js` and enable it when creating hyperclasses in `js/hbds_hyperclass_class.js` so attributes are positioned inside hyperclass borders and avoid overlaps.
- Improve hyperclass border/size calculation in `js/hbds_model.js` by expanding the layout sizing heuristic to account for contained children and attribute padding, producing more balanced spacing when `optimizeLayoutData` runs.
- Add an `Editable mode` UI toggle in `index.html` and wire behavior in `js/hbds_model.js`/app bootstrap so: when editable mode is enabled classes/hyperclasses are draggable and the canvas does not pan, and when disabled the canvas is pannable (2D) while node dragging is disabled.
- Make the overview viewport draggable and map viewport movement back to world coordinates so dragging the red rectangle pans the main diagram, implemented in `js/hbds_model.js` (`setupOverviewViewportDrag`, `overviewToWorld`).
- Preserve and reuse existing data-layer link APIs (`createLink`, `deleteLink`, etc.) while focusing this change on visual routing and interaction behavior.

### Testing
- No automated test suite was available in this repository, so no automated tests were executed for these runtime/interaction changes.
- Changes were validated via local code-level checks (static inspection and running repository commands) before committing the edit files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00fb9a6a1883318be76d500e8ed282)