### PR TITLE
Revert hyperclass attributes to render outside class bounds

### DIFF
--- a/js/hbds_hyperclass_class.js
+++ b/js/hbds_hyperclass_class.js
@@ -97,8 +97,8 @@ export function createHyperClass(scene, hyperClassData, options = {}) {
     textColor,
     startY: sz.height / 2 - 0.55,
     gapY: 0.16,
-    colX: sz.width / 2 - 0.35,
-    insideBounds: true,
+    colX: sz.width / 2 + 0.35,
+    insideBounds: false,
     hubPosition: hub.position.clone(),
     z: 0.08
   });


### PR DESCRIPTION
### Motivation
- Restore the previous visual layout so hyperclass attributes render outside the class shape by reverting the attribute placement options that moved them inside.

### Description
- In `js/hbds_hyperclass_class.js` changed `insideBounds: true` → `insideBounds: false` and `colX: sz.width / 2 - 0.35` → `colX: sz.width / 2 + 0.35` to place attribute column outside the hyperclass.

### Testing
- Inspected the file diff to confirm only `js/hbds_hyperclass_class.js` was modified and the change is limited to the two lines that adjust `insideBounds` and `colX`, and local validation checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00fd9d671483319f1d5f4e856603ba)