### PR TITLE
Add selectable editable modes and Apple-style smart menus in dynamic layout test

### DIFF
--- a/js/test_dynamic_hbds_layout.js
+++ b/js/test_dynamic_hbds_layout.js
@@ -6,11 +6,26 @@ import { getData,setData,resetData,validateData,createClass,deleteClass,createHy
 
 let scene,camera,renderer,labelRenderer,orbitControls,dragControls,diagramGroup; const draggableObjects=[];
 let selectedElementId=null,selectedParentHyperclassId=null,selectedAttributeOwnerId=null,selectedLinkSourceId=null,selectedLinkTargetId=null;
+let editMode='full';
 let nextClassNumber=1,nextHyperclassNumber=1,nextAttributeNumber=1,nextLinkNumber=1;
 const ctx=()=>({scene,camera,renderer,css2DRenderer:labelRenderer,orbitControls,dragControls,diagramGroup,draggableObjects,setDiagramGroup:(g)=>diagramGroup=g,setDragControls:(d)=>dragControls=d,setupDragControls:setupDrag,renderOnce});
 const shouldOptimizeAfterCrud=()=>document.getElementById('auto-optimize-toggle')?.checked===true;
 const idItems=()=>getData().hypergraph.class;
 function updateSmartMenusFromData(){ const nodes=(idItems()||[]).filter(Boolean), hy=nodes.filter(n=>n?.type==='hyperclass'); const set=(id,arr,sel,ph)=>{const el=document.getElementById(id);el.innerHTML=''; if(ph){const o=document.createElement('option');o.value='';o.textContent=ph;el.appendChild(o);} arr.forEach(n=>{const o=document.createElement('option');o.value=n.id;o.textContent=`${n.name} (${n.id})`;el.appendChild(o);}); if(sel!=null) el.value=String(sel);}; set('selected-element-select',nodes,selectedElementId,'-- Select element --'); set('parent-hyperclass-select',hy,selectedParentHyperclassId,'-- No parent hyperclass --'); set('attribute-owner-select',nodes,selectedAttributeOwnerId,'-- Select owner --'); set('link-source-select',nodes,selectedLinkSourceId,'-- Select source --'); set('link-target-select',nodes,selectedLinkTargetId,'-- Select target --'); }
+function updateAppleModeControls(){
+  const isReadOnly=editMode==='readonly';
+  const structureOnly=editMode==='structure';
+  const disable=(id,state)=>{const el=document.getElementById(id); if(el) el.disabled=state;};
+  disable('add-hyperclass-button',isReadOnly);
+  disable('add-class-button',isReadOnly);
+  disable('add-link-button',isReadOnly||structureOnly);
+  disable('add-attribute-button',isReadOnly||structureOnly);
+  disable('delete-selected-button',isReadOnly);
+  ['mode-full','mode-structure','mode-readonly'].forEach(id=>document.getElementById(id)?.classList.remove('active'));
+  document.getElementById(`mode-${editMode}`)?.classList.add('active');
+  const selectionGroup=document.getElementById('selected-element-select')?.closest('.control-group');
+  if(selectionGroup) selectionGroup.classList.toggle('muted',isReadOnly);
+}
 function updateJsonPreviewFromData(){ document.getElementById('json-preview').value=JSON.stringify(getData(),null,2); }
 function renderOnce(){ renderer.render(scene,camera); labelRenderer.render(scene,camera); }
 function ensureLighting(){
@@ -43,6 +58,11 @@ async function init(){ scene=new THREE.Scene(); scene.background=new THREE.Color
 ensureLighting();
 await setData({hypergraph:{class:[],link:[]}}, {context:ctx(),refresh:true}); updateSmartMenusFromData(); updateJsonPreviewFromData();
 document.getElementById('add-class-button').onclick=handleAddClass; document.getElementById('add-hyperclass-button').onclick=handleAddHyperclass; document.getElementById('add-attribute-button').onclick=handleAddAttribute; document.getElementById('add-link-button').onclick=handleAddLink; document.getElementById('delete-selected-button').onclick=handleDeleteSelected; document.getElementById('optimize-layout-button').onclick=()=>optimizeAndRefreshLayout(ctx()); document.getElementById('fit-model-button').onclick=()=>fitModelToCanvas(ctx(),{padding:1.2,updateOverview:true}); document.getElementById('save-model-button').onclick=()=>saveScene(ctx(),{fileName:'dynamic_hbds_test_model.json'}); document.getElementById('reset-model-button').onclick=async()=>{resetData({context:ctx(),refresh:true}); await afterCrud();};
+document.getElementById('edit-mode-select').onchange=(e)=>{editMode=e.target.value||'full'; updateAppleModeControls();};
+document.getElementById('mode-full').onclick=()=>{editMode='full'; document.getElementById('edit-mode-select').value='full'; updateAppleModeControls();};
+document.getElementById('mode-structure').onclick=()=>{editMode='structure'; document.getElementById('edit-mode-select').value='structure'; updateAppleModeControls();};
+document.getElementById('mode-readonly').onclick=()=>{editMode='readonly'; document.getElementById('edit-mode-select').value='readonly'; updateAppleModeControls();};
 ['selected-element-select','parent-hyperclass-select','attribute-owner-select','link-source-select','link-target-select'].forEach(id=>document.getElementById(id).onchange=(e)=>{const v=e.target.value||null; if(id==='selected-element-select') selectedElementId=v; if(id==='parent-hyperclass-select') selectedParentHyperclassId=v; if(id==='attribute-owner-select') selectedAttributeOwnerId=v; if(id==='link-source-select') selectedLinkSourceId=v; if(id==='link-target-select') selectedLinkTargetId=v;});
+updateAppleModeControls();
 (function anim(){requestAnimationFrame(anim); orbitControls.update(); renderOnce();})(); }
 init();

--- a/test_dynamic_hbds_layout.html
+++ b/test_dynamic_hbds_layout.html
@@ -5,19 +5,25 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>HBDS Dynamic Layout Test</title>
   <style>
-    html, body { margin: 0; height: 100%; overflow: hidden; font-family: Arial, sans-serif; }
+    html, body { margin: 0; height: 100%; overflow: hidden; font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, Helvetica, Arial, sans-serif; }
     #container { position: fixed; inset: 0; background: #f4f4f4; }
     #model-overview { position: fixed; top: 10px; left: 10px; width: 220px; height: 150px; border: 1px solid #999; background: rgba(255,255,255,.95); z-index: 20; }
     #model-overview-canvas { width: 100%; height: 100%; display: block; }
     #model-overview-viewport { position: absolute; border: 1px dashed #d00; pointer-events: none; }
-    #dynamic-test-panel { position: fixed; top: 0; right: 0; width: 360px; height: 100%; overflow: auto; background: rgba(255,255,255,0.97); border-left: 1px solid #ccc; padding: 12px; z-index: 30; }
-    .control-group { margin-bottom: 10px; display: grid; gap: 6px; }
-    .control-group button { padding: 7px 8px; }
-    select, textarea, button { width: 100%; box-sizing: border-box; }
+    #dynamic-test-panel { position: fixed; top: 0; right: 0; width: 360px; height: 100%; overflow: auto; background: rgba(255,255,255,0.72); backdrop-filter: blur(18px) saturate(1.2); border-left: 1px solid rgba(255,255,255,.6); padding: 12px; z-index: 30; box-shadow: -12px 0 40px rgba(0,0,0,.08); }
+    .control-group { margin-bottom: 10px; display: grid; gap: 6px; background: rgba(255,255,255,.55); border: 1px solid rgba(0,0,0,.06); border-radius: 12px; padding: 10px; }
+    .control-group button { padding: 8px 10px; border-radius: 10px; border: 1px solid rgba(0,0,0,.1); background: linear-gradient(#fff, #f4f4f6); }
+    .control-group button:hover { background: linear-gradient(#fff, #ececf0); }
+    select, textarea, button { width: 100%; box-sizing: border-box; font: inherit; }
+    select, textarea { border-radius: 10px; border: 1px solid rgba(0,0,0,.15); padding: 8px; background: rgba(255,255,255,.92); }
     textarea { min-height: 160px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
     #layout-status { background: #111; color: #e7ffe7; padding: 8px; min-height: 130px; white-space: pre-wrap; }
     .label { pointer-events: auto; cursor: pointer; }
     .inline-hint { font-size: 12px; color: #444; }
+    .mode-segment { display: grid; grid-template-columns: repeat(3,1fr); gap: 6px; }
+    .mode-segment button { font-size: 12px; }
+    .mode-segment button.active { background: linear-gradient(#0a84ff,#0066db); color: #fff; border-color: #0066db; }
+    .muted { opacity: .6; pointer-events: none; }
   </style>
 <script type="importmap">{"imports":{"three":"https://unpkg.com/three@0.176.0/build/three.module.js","three/addons/":"https://unpkg.com/three@0.176.0/examples/jsm/"}}</script>
 </head>
@@ -25,7 +31,19 @@
   <div id="container"></div>
   <div id="model-overview"><canvas id="model-overview-canvas"></canvas><div id="model-overview-viewport"></div></div>
   <div id="dynamic-test-panel"><h2>HBDS Dynamic Layout Test</h2>
-    <div class="control-group"><label for="test-model-select">Select HDBS Model</label><select id="test-model-select"></select></div>
+    <div class="control-group"><label for="test-model-select">Select HDBS Model</label><select id="test-model-select"></select>
+      <label for="edit-mode-select">Editable Mode</label>
+      <select id="edit-mode-select">
+        <option value="full">Full Edit</option>
+        <option value="structure">Structure Only</option>
+        <option value="readonly">Read Only</option>
+      </select>
+      <div class="mode-segment">
+        <button id="mode-full" type="button">Full</button>
+        <button id="mode-structure" type="button">Structure</button>
+        <button id="mode-readonly" type="button">Read Only</button>
+      </div>
+    </div>
     <div class="control-group"><button id="add-hyperclass-button">Add Hyperclass</button><button id="add-class-button">Add Class</button><button id="add-attribute-button">Add Attribute</button><button id="add-link-button">Add Link</button></div>
     <div class="control-group"><button id="delete-selected-button">Delete Selected</button><button id="optimize-layout-button">Optimize Layout</button><button id="fit-model-button">Fit Model</button><button id="save-model-button">Save Model</button><button id="reset-model-button">Reset Test Model</button></div>
     <div class="control-group"><button id="export-json-button">Export JSON</button></div>


### PR DESCRIPTION
### Motivation
- Make the dynamic HBDS layout test UI more usable by adding selectable editing modes so testers can switch between full editing, structure-only edits, and read-only inspection.
- Improve the right-side test panel visuals and controls to an Apple-like appearance for clearer affordances and quicker mode switching.

### Description
- Updated `test_dynamic_hbds_layout.html` to add an `Editable Mode` dropdown, an Apple-style segmented control, and refreshed panel and control CSS (translucent blur, rounded cards/buttons, gradients, updated system font stack).
- Added `editMode` state and `updateAppleModeControls()` in `js/test_dynamic_hbds_layout.js` to enable/disable create/delete/link/attribute actions according to the selected mode and to toggle an active state on the segmented buttons.
- Wired the dropdown and segmented buttons to stay in sync and applied the initial mode state on startup by calling `updateAppleModeControls()` from `init()`.
- Kept changes limited to the UI/test harness only with no changes to backend/data formats or model logic.

### Testing
- The patch applied successfully and updated `test_dynamic_hbds_layout.html` and `js/test_dynamic_hbds_layout.js` without errors.
- A commit was created with message `Add editable modes and Apple-style smart menu UI` and the repository state is clean per `git status --short`.
- No automated unit/integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0100d78ea8833181b43c55f2241f7f)