### PR TITLE
Add model catalog + manifest and selectable layout algorithms (grid/hierarchy/radial)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ This project provides an interactive visualization tool for **Hypergraph-Based D
 
 * **Interactive 2D & 3D Views**: Seamlessly switch between a 2D pannable layout and a full 3D orbital view.
 * **Dynamic Model Loading**: Load different HBDS models on-the-fly from external JSON files.
+* **Model Catalog Manifest**: Populate the model selector from `/models/models_manifest.json`.
 * **Direct Manipulation**: Drag and drop class entities to organize your diagram in 2D view.
 * **Fallback Gracefully**: Automatically loads a default model if a specified one isn't found.
+* **Multiple Layout Algorithms**: Optimize node placement with `grid`, `hierarchy`, or `radial` layout modes.
 
 ### Built With
 

--- a/index.html
+++ b/index.html
@@ -49,6 +49,20 @@
         <button id="optimize-layout-button">Optimize Layout</button>
     </div>
     <div class="control-group">
+        <label for="layout-algorithm-select">Layout Algorithm</label>
+        <select id="layout-algorithm-select">
+            <option value="grid">Grid (default)</option>
+            <option value="hierarchy">Hierarchy</option>
+            <option value="radial">Radial</option>
+        </select>
+    </div>
+    <div class="control-group">
+        <label class="checkbox-wrapper" for="auto-optimize-toggle">
+            <input type="checkbox" id="auto-optimize-toggle">
+            <span>Auto optimize on model load</span>
+        </label>
+    </div>
+    <div class="control-group">
         <button id="fit-model-button">Fit Model</button>
     </div>
 </div>
@@ -71,7 +85,7 @@
     import {updateLabelFontSizes as updateHyperClassLabelFontSizes} from './js/hbds_hyperclass_class.js';
     import { updateLinkFontSizes, recalculateAllLinks } from './js/hbds_class_link.js';
     import { updateLinkFontSizes as updateHyperClassLinkFontSizes } from './js/hbds_hyperclass_link.js';
-    import { loadAndRenderScene, saveScene, optimizeAndRefreshLayout, fitModelToCanvas, initModelOverview, updateModelOverview, setupCanvasPanControls } from './js/hbds_model.js';
+    import { loadAndRenderScene, saveScene, optimizeAndRefreshLayout, fitModelToCanvas, initModelOverview, updateModelOverview, setupCanvasPanControls, listAvailableModels } from './js/hbds_model.js';
 
     /* ---------- Globals ---------- */
     let scene, camera, renderer, css2DRenderer, orbitControls, dragControls;
@@ -80,6 +94,7 @@
 
     /* ---------- MAIN APPLICATION ---------- */
     function init() {
+        bootstrapModelCatalog();
         scene = new THREE.Scene();
         scene.background = new THREE.Color('#f0f0f0');
 
@@ -125,13 +140,20 @@
             saveScene(getModelContext(), { fileName });
         });
         document.getElementById('optimize-layout-button').addEventListener('click', async () => {
+            const algorithm = document.getElementById('layout-algorithm-select').value;
             await optimizeAndRefreshLayout(getModelContext(), {
+                algorithm,
                 fitAfterOptimize: true
             });
             fitModelToCanvas(getModelContext(), { padding: 1.15, updateOverview: true });
         });
         document.getElementById('model-select').addEventListener('change', async e => {
             await loadAndRenderScene(e.target.value, getModelContext());
+            if (document.getElementById('auto-optimize-toggle').checked) {
+                await optimizeAndRefreshLayout(getModelContext(), {
+                    algorithm: document.getElementById('layout-algorithm-select').value
+                });
+            }
             fitModelToCanvas(getModelContext(), { padding: 1.15, updateOverview: true });
         });
         document.getElementById('fit-model-button').addEventListener('click', () => {
@@ -143,6 +165,19 @@
         initModelOverview(getModelContext());
         loadAndRenderScene('human', getModelContext()).then(() => {
             fitModelToCanvas(getModelContext(), { padding: 1.15, updateOverview: true });
+        });
+    }
+    async function bootstrapModelCatalog() {
+        const select = document.getElementById('model-select');
+        const models = await listAvailableModels();
+        if (!Array.isArray(models) || models.length === 0) return;
+        select.innerHTML = '';
+        models.forEach((model) => {
+            const option = document.createElement('option');
+            option.value = model.value;
+            option.textContent = model.label;
+            if (model.description) option.title = model.description;
+            select.appendChild(option);
         });
     }
 

--- a/js/hbds_model.js
+++ b/js/hbds_model.js
@@ -312,7 +312,37 @@ export const readLink=(idOrPred)=>typeof idOrPred==='function'?data.hypergraph.l
 export const createLink=(input,options={})=>commitDataChange('createLink',d=>{const l=createLinkData(input); const byId=new Map(d.hypergraph.class.map(c=>[c.id,c])); const v=validateLinkData(l,byId); if(!v.valid) throw new Error(v.errors.join('; ')); d.hypergraph.link.push(l); return l;},options);
 export const updateLink=(idOrPred,patch,options={})=>commitDataChange('updateLink',d=>{const i=d.hypergraph.link.findIndex(l=>typeof idOrPred==='function'?idOrPred(l):l.id===idOrPred); if(i<0) throw new Error('link not found'); d.hypergraph.link[i]=updateLinkData(d.hypergraph.link[i],patch);},options);
 export const deleteLink=(idOrPred,options={})=>commitDataChange('deleteLink',d=>{d.hypergraph.link=d.hypergraph.link.filter(l=>!(typeof idOrPred==='function'?idOrPred(l):l.id===idOrPred||(idOrPred?.sourceClassId===l.sourceClassId&&idOrPred?.targetClassId===l.targetClassId)));},options);
-export async function loadAndRenderScene(modelName, context){ const raw=await HyperClassLoader.load(modelName).catch(()=>ClassLoader.load(modelName)); setData(raw,{context,refresh:true}); return getData(); }
+async function loadModelData(modelName){
+  const value=String(modelName||'').trim();
+  const isDirectPath=value.includes('/') || value.endsWith('.json');
+  if(isDirectPath){
+    const response=await fetch(`./${value}`);
+    if(!response.ok) throw new Error(`Model not found: ${value}`);
+    return response.json();
+  }
+  try {
+    return await HyperClassLoader.load(value);
+  } catch {
+    return ClassLoader.load(value);
+  }
+}
+export async function listAvailableModels(manifestPath='models/models_manifest.json'){
+  try {
+    const response=await fetch(`./${manifestPath}`);
+    if(!response.ok) throw new Error(`manifest not found: ${manifestPath}`);
+    const manifest=await response.json();
+    const items=Array.isArray(manifest?.models)?manifest.models:[];
+    return items.filter(Boolean).map(item=>({
+      value:item.value||item.path||item.id||'',
+      label:item.label||item.name||item.value||'',
+      description:item.description||'',
+      tags:Array.isArray(item.tags)?item.tags:[]
+    })).filter(item=>item.value);
+  } catch {
+    return [];
+  }
+}
+export async function loadAndRenderScene(modelName, context){ const raw=await loadModelData(modelName); setData(raw,{context,refresh:true}); return getData(); }
 export function saveScene(context, options={}){ const blob=new Blob([JSON.stringify(getData(),null,2)],{type:'application/json'}); const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download=options.fileName||'hbds_saved_model.json'; a.click(); URL.revokeObjectURL(url); return getData(); }
 function getNodeSize(node){
   const base=node?.size||{};
@@ -335,7 +365,7 @@ function getGridDimensions(childCount){
   const cols=Math.ceil(Math.sqrt(childCount));
   return {cols,rows:Math.ceil(childCount/cols)};
 }
-function optimizeLayoutData(){
+function optimizeLayoutGrid(){
   const nodes=data.hypergraph.class||[];
   const byId=new Map(nodes.map(n=>[n.id,n]));
   const childrenByParent=new Map();
@@ -384,4 +414,52 @@ function optimizeLayoutData(){
     layoutNode(root,x,y);
   });
 }
-export async function optimizeAndRefreshLayout(context, options={}){ optimizeLayoutData(); refreshSceneFromData(context); updateLayoutFromData(context,options); }
+function optimizeLayoutRadial(){
+  const nodes=data.hypergraph.class||[];
+  const roots=nodes.filter(n=>!n.parentClassId).sort((a,b)=>String(a.name).localeCompare(String(b.name)));
+  const radiusStep = 5;
+  roots.forEach((root, idx)=>{
+    const angle=(Math.PI*2*idx)/Math.max(roots.length,1);
+    if(!root.position) root.position={x:0,y:0,z:0};
+    root.position.x=Math.cos(angle)*radiusStep;
+    root.position.y=Math.sin(angle)*radiusStep;
+    root.position.z=0;
+  });
+}
+function optimizeLayoutHierarchy(){
+  const nodes=data.hypergraph.class||[];
+  const childrenByParent=new Map();
+  nodes.forEach(n=>{ if(n.parentClassId){ const a=childrenByParent.get(n.parentClassId)||[]; a.push(n); childrenByParent.set(n.parentClassId,a); } });
+  const roots=nodes.filter(n=>!n.parentClassId).sort((a,b)=>String(a.name).localeCompare(String(b.name)));
+  const rowGap=3.8, colGap=4.2;
+  function layoutLevel(parent, depth, centerX){
+    const kids=(childrenByParent.get(parent.id)||[]).sort((a,b)=>String(a.name).localeCompare(String(b.name)));
+    kids.forEach((child,i)=>{
+      const offset=i-(kids.length-1)/2;
+      if(!child.position) child.position={x:0,y:0,z:0};
+      child.position.x=centerX+offset*colGap;
+      child.position.y=-depth*rowGap;
+      child.position.z=0;
+      layoutLevel(child, depth+1, child.position.x);
+    });
+  }
+  roots.forEach((root, i)=>{
+    if(!root.position) root.position={x:0,y:0,z:0};
+    root.position.x=(i-(roots.length-1)/2)*colGap*1.2;
+    root.position.y=0;
+    root.position.z=0;
+    layoutLevel(root,1,root.position.x);
+  });
+}
+function applyLayoutByAlgorithm(algorithm='grid'){
+  if(algorithm==='radial') return optimizeLayoutRadial();
+  if(algorithm==='hierarchy') return optimizeLayoutHierarchy();
+  return optimizeLayoutGrid();
+}
+export async function optimizeAndRefreshLayout(context, options={}){
+  const algorithm=options.algorithm||'grid';
+  applyLayoutByAlgorithm(algorithm);
+  refreshSceneFromData(context);
+  updateLayoutFromData(context,options);
+  return { algorithm };
+}

--- a/models/models_manifest.json
+++ b/models/models_manifest.json
@@ -1,0 +1,16 @@
+{
+  "models": [
+    { "value": "human", "label": "Human", "description": "Base human class model", "tags": ["starter"] },
+    { "value": "human_and_car", "label": "Human + Car", "description": "Simple two-entity model", "tags": ["starter"] },
+    { "value": "human_and_car_and_more", "label": "Human + Car + More", "description": "Extended sample model", "tags": ["sample"] },
+    { "value": "transportation", "label": "Transportation", "description": "Transportation entities", "tags": ["domain"] },
+    { "value": "transportation_links", "label": "Transportation + Links", "description": "Transportation with explicit links", "tags": ["domain"] },
+    { "value": "human_and_car_links", "label": "Human + Car + Links", "description": "Linked human-car sample", "tags": ["sample"] },
+    { "value": "bridge_road_links", "label": "Bridge + Road Links", "description": "Infrastructure links demo", "tags": ["domain"] },
+    { "value": "models/hyperclass_mail_Carrier.json", "label": "Hyperclass Mail Carrier", "description": "Hyperclass sample", "tags": ["hyperclass"] },
+    { "value": "models/hyperclass_mail_Carrier_with_links.json", "label": "Hyperclass Mail Carrier + Links", "description": "Hyperclass with links", "tags": ["hyperclass"] },
+    { "value": "models/complex_hyperclass_mail_Carrier_with_links.json", "label": "Complex Hyperclass Mail Carrier + Links", "description": "Large hyperclass sample", "tags": ["hyperclass", "complex"] },
+    { "value": "models/opera_de Paris.json", "label": "Opera de Paris", "description": "Cultural domain sample", "tags": ["domain"] },
+    { "value": "models/TGV.json", "label": "TGV", "description": "Railway sample model", "tags": ["domain"] }
+  ]
+}


### PR DESCRIPTION
### Motivation

- Provide a dynamic model catalog so the model selector can be populated from a manifest file and support more flexible model loading semantics. 
- Allow choosing different layout algorithms and optionally auto-optimizing after load to improve diagram arrangement for different model shapes.

### Description

- Add `models/models_manifest.json` and a new exported function `listAvailableModels` in `js/hbds_model.js` to load and normalize a manifest and populate the UI model selector.  
- Introduce `loadModelData` to support direct JSON paths as well as existing `HyperClassLoader`/`ClassLoader` resolution and wire it into `loadAndRenderScene`.  
- Add UI controls in `index.html` and `index.js`: a `layout-algorithm-select`, an `auto-optimize-toggle`, and `bootstrapModelCatalog` which calls `listAvailableModels` to populate the model dropdown.  
- Refactor and split layout logic into `optimizeLayoutGrid` (refactored original grid algorithm), add `optimizeLayoutRadial` and `optimizeLayoutHierarchy`, provide `applyLayoutByAlgorithm`, and update `optimizeAndRefreshLayout` to accept an `options.algorithm` parameter and return the chosen algorithm.  
- Update `README.md` to document the manifest-driven model catalog and the new layout algorithm options.

### Testing

- No automated tests were added or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01035482e88331830ca636fe0ab604)