### PR TITLE
Satellite model: switch to Radial layout and add lifecycle attributes + links

### DIFF
--- a/models/satellite_world_simple_structure.json
+++ b/models/satellite_world_simple_structure.json
@@ -3,11 +3,11 @@
   "metadata": {
     "id": "satellite_world_simple_structure",
     "name": "Satellite World Simple Structure",
-    "version": "2026.05.18-simple-grid-metallic",
-    "description": "Simple HBDS satellite model aligned to CelesTrak-style satellite metadata.",
+    "version": "2026.05.18-simple-radial-metallic",
+    "description": "Simple HBDS satellite model with richer lifecycle/spacecraft metadata and radial layout.",
     "layout": {
-      "algorithm": "grid",
-      "mode": "grid"
+      "algorithm": "radial",
+      "mode": "Radial"
     },
     "style": {
       "classMaterial": "metallic",
@@ -21,80 +21,318 @@
         "id": "hc_satellite_catalog",
         "name": "Satellite Catalog",
         "type": "hyperclass",
-        "attributes": ["Catalog authority", "Object identity", "Launch lineage"],
-        "children": ["satellite", "launch_vehicle", "organization"],
-        "position": {"x": -6.0, "y": 0.0, "z": 0.0},
-        "size": {"width": 10.0, "height": 6.0},
-        "rendering": {"class": {"color": "#DBEAFE", "material": "metallic", "borderColor": "#1D4ED8", "borderWidth": 0.025, "cornerRadius": 0.12}}
+        "attributes": [
+          "Catalog authority",
+          "Object identity",
+          "Launch lineage"
+        ],
+        "children": [
+          "satellite",
+          "launch_vehicle",
+          "organization"
+        ],
+        "position": {
+          "x": -6.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "size": {
+          "width": 10.0,
+          "height": 6.0
+        },
+        "rendering": {
+          "class": {
+            "color": "#DBEAFE",
+            "material": "metallic",
+            "borderColor": "#1D4ED8",
+            "borderWidth": 0.025,
+            "cornerRadius": 0.12
+          }
+        }
       },
       {
         "id": "hc_orbit_payload",
         "name": "Orbit / Payload",
         "type": "hyperclass",
-        "attributes": ["Orbital state", "Payload mission", "TLE traceability"],
-        "children": ["tle_set", "payload_profile"],
-        "position": {"x": 6.0, "y": 0.0, "z": 0.0},
-        "size": {"width": 7.0, "height": 6.0},
-        "rendering": {"class": {"color": "#DCFCE7", "material": "metallic", "borderColor": "#15803D", "borderWidth": 0.025, "cornerRadius": 0.12}}
+        "attributes": [
+          "Orbital state",
+          "Payload mission",
+          "TLE traceability"
+        ],
+        "children": [
+          "tle_set",
+          "payload_profile"
+        ],
+        "position": {
+          "x": 6.0,
+          "y": 0.0,
+          "z": 0.0
+        },
+        "size": {
+          "width": 7.0,
+          "height": 6.0
+        },
+        "rendering": {
+          "class": {
+            "color": "#DCFCE7",
+            "material": "metallic",
+            "borderColor": "#15803D",
+            "borderWidth": 0.025,
+            "cornerRadius": 0.12
+          }
+        }
       },
       {
         "id": "satellite",
         "name": "Satellite",
         "type": "roundedRectangle",
         "parentClassId": "hc_satellite_catalog",
-        "attributes": ["noradCatalogId", "satelliteName", "payloadType", "capacityClass", "launchDateUtc", "manufacturerOrgId"],
-        "position": {"x": -8.0, "y": 1.0, "z": 0.1},
-        "size": {"width": 2.8, "height": 1.6},
-        "rendering": {"class": {"color": "#2563EB", "material": "metallic", "borderColor": "#1E293B", "borderWidth": 0.025, "cornerRadius": 0.12}}
+        "attributes": [
+          "noradCatalogId",
+          "satelliteName",
+          "internationalDesignator",
+          "cosparId",
+          "satelliteStatus",
+          "busType",
+          "dryMassKg",
+          "powerWatts",
+          "manufacturerOrgId",
+          "operatorOrgId",
+          "launchDateUtc",
+          "decayedDateUtc"
+        ],
+        "position": {
+          "x": -8.0,
+          "y": 1.0,
+          "z": 0.1
+        },
+        "size": {
+          "width": 2.8,
+          "height": 1.6
+        },
+        "rendering": {
+          "class": {
+            "color": "#2563EB",
+            "material": "metallic",
+            "borderColor": "#1E293B",
+            "borderWidth": 0.025,
+            "cornerRadius": 0.12
+          }
+        }
       },
       {
         "id": "launch_vehicle",
         "name": "Launch Vehicle",
         "type": "roundedRectangle",
         "parentClassId": "hc_satellite_catalog",
-        "attributes": ["rocketName", "rocketFamily", "launchSite", "launchProvider", "launchSuccess"],
-        "position": {"x": -4.0, "y": 1.0, "z": 0.1},
-        "size": {"width": 2.8, "height": 1.6},
-        "rendering": {"class": {"color": "#3B82F6", "material": "metallic", "borderColor": "#1E293B", "borderWidth": 0.025, "cornerRadius": 0.12}}
+        "attributes": [
+          "rocketName",
+          "rocketFamily",
+          "launchSite",
+          "launchProvider",
+          "launchSuccess",
+          "launchMassToLeoKg",
+          "launchMassToGtoKg",
+          "firstFlightDate"
+        ],
+        "position": {
+          "x": -4.0,
+          "y": 1.0,
+          "z": 0.1
+        },
+        "size": {
+          "width": 2.8,
+          "height": 1.6
+        },
+        "rendering": {
+          "class": {
+            "color": "#3B82F6",
+            "material": "metallic",
+            "borderColor": "#1E293B",
+            "borderWidth": 0.025,
+            "cornerRadius": 0.12
+          }
+        }
       },
       {
         "id": "organization",
         "name": "Organization",
         "type": "roundedRectangle",
         "parentClassId": "hc_satellite_catalog",
-        "attributes": ["organizationId", "name", "country", "role"],
-        "position": {"x": -6.0, "y": -1.3, "z": 0.1},
-        "size": {"width": 2.8, "height": 1.6},
-        "rendering": {"class": {"color": "#60A5FA", "material": "metallic", "borderColor": "#1E293B", "borderWidth": 0.025, "cornerRadius": 0.12}}
+        "attributes": [
+          "organizationId",
+          "name",
+          "country",
+          "role",
+          "organizationType",
+          "foundedDate"
+        ],
+        "position": {
+          "x": -6.0,
+          "y": -1.3,
+          "z": 0.1
+        },
+        "size": {
+          "width": 2.8,
+          "height": 1.6
+        },
+        "rendering": {
+          "class": {
+            "color": "#60A5FA",
+            "material": "metallic",
+            "borderColor": "#1E293B",
+            "borderWidth": 0.025,
+            "cornerRadius": 0.12
+          }
+        }
       },
       {
         "id": "tle_set",
         "name": "TLE Set",
         "type": "roundedRectangle",
         "parentClassId": "hc_orbit_payload",
-        "attributes": ["tleEpochUtc", "tleLine1", "tleLine2", "inclinationDeg", "meanMotionRevPerDay"],
-        "position": {"x": 4.6, "y": 0.8, "z": 0.1},
-        "size": {"width": 2.8, "height": 1.6},
-        "rendering": {"class": {"color": "#22C55E", "material": "metallic", "borderColor": "#1E293B", "borderWidth": 0.025, "cornerRadius": 0.12}}
+        "attributes": [
+          "tleEpochUtc",
+          "tleLine1",
+          "tleLine2",
+          "inclinationDeg",
+          "eccentricity",
+          "meanMotionRevPerDay",
+          "raanDeg",
+          "argPerigeeDeg"
+        ],
+        "position": {
+          "x": 4.6,
+          "y": 0.8,
+          "z": 0.1
+        },
+        "size": {
+          "width": 2.8,
+          "height": 1.6
+        },
+        "rendering": {
+          "class": {
+            "color": "#22C55E",
+            "material": "metallic",
+            "borderColor": "#1E293B",
+            "borderWidth": 0.025,
+            "cornerRadius": 0.12
+          }
+        }
       },
       {
         "id": "payload_profile",
         "name": "Payload Profile",
         "type": "roundedRectangle",
         "parentClassId": "hc_orbit_payload",
-        "attributes": ["payloadType", "missionClass", "capacityDescriptor", "operatorOrgId"],
-        "position": {"x": 7.4, "y": 0.8, "z": 0.1},
-        "size": {"width": 2.8, "height": 1.6},
-        "rendering": {"class": {"color": "#4ADE80", "material": "metallic", "borderColor": "#1E293B", "borderWidth": 0.025, "cornerRadius": 0.12}}
+        "attributes": [
+          "payloadType",
+          "missionClass",
+          "capacityDescriptor",
+          "frequencyBand",
+          "coverageRegion",
+          "designLifeYears",
+          "operatorOrgId"
+        ],
+        "position": {
+          "x": 7.4,
+          "y": 0.8,
+          "z": 0.1
+        },
+        "size": {
+          "width": 2.8,
+          "height": 1.6
+        },
+        "rendering": {
+          "class": {
+            "color": "#4ADE80",
+            "material": "metallic",
+            "borderColor": "#1E293B",
+            "borderWidth": 0.025,
+            "cornerRadius": 0.12
+          }
+        }
       }
     ],
     "relationship": [
-      {"id": "rel_simple_001", "sourceClassId": "satellite", "targetClassId": "launch_vehicle", "name": "launched_by"},
-      {"id": "rel_simple_002", "sourceClassId": "satellite", "targetClassId": "organization", "name": "manufactured_by"},
-      {"id": "rel_simple_003", "sourceClassId": "satellite", "targetClassId": "tle_set", "name": "tracked_by_tle"},
-      {"id": "rel_simple_004", "sourceClassId": "satellite", "targetClassId": "payload_profile", "name": "carries_payload"},
-      {"id": "rel_simple_005", "sourceClassId": "organization", "targetClassId": "payload_profile", "name": "operates_payload"},
-      {"id": "rel_simple_006", "sourceClassId": "hc_satellite_catalog", "targetClassId": "hc_orbit_payload", "name": "supplies_orbital_payload_context"}
+      {
+        "id": "rel_simple_001",
+        "sourceClassId": "satellite",
+        "targetClassId": "launch_vehicle",
+        "name": "launched_by"
+      },
+      {
+        "id": "rel_simple_002",
+        "sourceClassId": "satellite",
+        "targetClassId": "organization",
+        "name": "manufactured_by"
+      },
+      {
+        "id": "rel_simple_003",
+        "sourceClassId": "satellite",
+        "targetClassId": "tle_set",
+        "name": "tracked_by_tle"
+      },
+      {
+        "id": "rel_simple_004",
+        "sourceClassId": "satellite",
+        "targetClassId": "payload_profile",
+        "name": "carries_payload"
+      },
+      {
+        "id": "rel_simple_005",
+        "sourceClassId": "organization",
+        "targetClassId": "payload_profile",
+        "name": "operates_payload"
+      },
+      {
+        "id": "rel_simple_006",
+        "sourceClassId": "hc_satellite_catalog",
+        "targetClassId": "hc_orbit_payload",
+        "name": "supplies_orbital_payload_context"
+      },
+      {
+        "id": "rel_simple_007",
+        "sourceClassId": "satellite",
+        "targetClassId": "organization",
+        "name": "operated_by"
+      },
+      {
+        "id": "rel_simple_008",
+        "sourceClassId": "satellite",
+        "targetClassId": "organization",
+        "name": "owned_by"
+      },
+      {
+        "id": "rel_simple_009",
+        "sourceClassId": "launch_vehicle",
+        "targetClassId": "organization",
+        "name": "provided_by"
+      },
+      {
+        "id": "rel_simple_010",
+        "sourceClassId": "organization",
+        "targetClassId": "launch_vehicle",
+        "name": "procures_launch"
+      },
+      {
+        "id": "rel_simple_011",
+        "sourceClassId": "payload_profile",
+        "targetClassId": "tle_set",
+        "name": "characterized_by_orbit_solution"
+      },
+      {
+        "id": "rel_simple_012",
+        "sourceClassId": "launch_vehicle",
+        "targetClassId": "payload_profile",
+        "name": "deploys_payload_profile"
+      },
+      {
+        "id": "rel_simple_013",
+        "sourceClassId": "hc_orbit_payload",
+        "targetClassId": "satellite",
+        "name": "describes_satellite_orbital_mission_state"
+      }
     ]
   }
 }

--- a/models/validate_satellite_models.py
+++ b/models/validate_satellite_models.py
@@ -49,7 +49,7 @@ def validate(path):
         assert r['sourceClassId'] in by, f"Missing source {r['id']}"
         assert r['targetClassId'] in by, f"Missing target {r['id']}"
     layout=d.get('metadata',{}).get('layout',{})
-    assert layout.get('mode')=='grid', 'Layout mode is not grid'
+    assert layout.get('mode') in {'grid','Grid','radial','Radial'}, 'Layout mode must be grid or radial'
     print(f'OK: {path}')
 
 if __name__=='__main__':


### PR DESCRIPTION
### Motivation
- Make the simple satellite HBDS model more expressive by adding lifecycle/platform metadata and more meaningful links so the graph better represents satellite ownership, operations and orbital context.
- Enable visualization using a radial layout to support radial-oriented renderers and layout tests.

### Description
- Updated `models/satellite_world_simple_structure.json` metadata to use a radial layout (`"algorithm": "radial"`, `"mode": "Radial"`) and bumped the `version`/`description` to reflect the change.
- Expanded core entity attributes for `satellite`, `launch_vehicle`, `organization`, `tle_set`, and `payload_profile` to include lifecycle and spacecraft fields such as `busType`, `launchDateUtc`, `decayedDateUtc`, mass/power fields, orbital elements and additional descriptive fields.
- Added new semantic relationships (e.g. `operated_by`, `owned_by`, `provided_by`, `procures_launch`, `characterized_by_orbit_solution`, `deploys_payload_profile`, and `describes_satellite_orbital_mission_state`) to improve connectivity between satellites, organizations, launch vehicles, payloads and orbit context.
- Updated `models/validate_satellite_models.py` layout validation to accept both grid and radial layout modes by allowing `mode` values in `{'grid','Grid','radial','Radial'}`.

### Testing
- Ran `python models/validate_satellite_models.py` which validated both the complete and updated simple model and reported OK.
- Ran `python -m json.tool models/satellite_world_simple_structure.json >/dev/null` to verify JSON formatting which succeeded.
- Ran `node --check js/test_dynamic_hbds_layout.js` which completed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b60c0fb4883319c45d18a3cce7f8f)