### PR TITLE
Fix satellite model links and metadata-driven radial layout

### DIFF
--- a/js/hbds_class_link.js
+++ b/js/hbds_class_link.js
@@ -32,15 +32,17 @@ export function createLinkBetweenClass(linkData, classById) {
 
   const rendering = linkData.rendering ?? {};
   const lineStyle = rendering.lineStyle ?? 'solid';
-  const Material = lineStyle === 'dashed' || lineStyle === 'dotted'
-    ? THREE.LineDashedMaterial
-    : THREE.LineBasicMaterial;
-  const mat = new Material({
+  const isDashed = lineStyle === 'dashed' || lineStyle === 'dotted';
+  const Material = isDashed ? THREE.LineDashedMaterial : THREE.LineBasicMaterial;
+  const materialOptions = {
     color: rendering.lineColor ?? '#333333',
-    linewidth: rendering.lineWidth ?? 2,
-    dashSize: lineStyle === 'dotted' ? 0.04 : 0.18,
-    gapSize: lineStyle === 'dotted' ? 0.08 : 0.12
-  });
+    linewidth: rendering.lineWidth ?? 2
+  };
+  if (isDashed) {
+    materialOptions.dashSize = lineStyle === 'dotted' ? 0.04 : 0.18;
+    materialOptions.gapSize = lineStyle === 'dotted' ? 0.08 : 0.12;
+  }
+  const mat = new Material(materialOptions);
 
   const geometry = new THREE.BufferGeometry();
   const line = new THREE.Line(geometry, mat);

--- a/js/hbds_model.js
+++ b/js/hbds_model.js
@@ -58,8 +58,11 @@ export function normalizeData(inputData){
     }
     if(Array.isArray(m.hypergraph.class)) flattened.push(...m.hypergraph.class);
     m.hypergraph.class=flattened;
-    m.hypergraph.link=Array.isArray(m.hypergraph.relationships)
-      ? m.hypergraph.relationships.map(rel=>({
+    const legacyRelationships=Array.isArray(m.hypergraph.relationships)
+      ? m.hypergraph.relationships
+      : (Array.isArray(m.hypergraph.relationship)?m.hypergraph.relationship:[]);
+    m.hypergraph.link=legacyRelationships.length
+      ? legacyRelationships.map(rel=>({
           ...rel,
           sourceClassId:rel.sourceClassId??rel.source,
           targetClassId:rel.targetClassId??rel.target,
@@ -724,7 +727,25 @@ async function loadTextResource(path){
   }
   throw new Error('No browser request API available');
 }
-export async function loadAndRenderScene(modelName, context, options={}){ const raw=await loadModelData(modelName,options); setData(raw,{context,refresh:true}); return getData(); }
+export async function loadAndRenderScene(modelName, context, options={}){
+  const raw=await loadModelData(modelName,options);
+  setData(raw,{context,refresh:true});
+  const loaded=getData();
+  const layoutAlgorithm=loaded?.metadata?.layout?.algorithm || 'none';
+  if(options.autoApplyLayout!==false && layoutAlgorithm!=='none' && modelNeedsLayoutPlacement(loaded)){
+    await optimizeAndRefreshLayout(context,{ algorithm:layoutAlgorithm });
+  }
+  return getData();
+}
+
+function modelNeedsLayoutPlacement(model){
+  const nodes=Array.isArray(model?.hypergraph?.class)?model.hypergraph.class:[];
+  if(!nodes.length) return false;
+  return nodes.some(node=>{
+    const p=node?.position;
+    return !p || !Number.isFinite(Number(p.x)) || !Number.isFinite(Number(p.y));
+  });
+}
 export function saveScene(context, options={}){ if(options.updateFitMetadata!==false) updateFitMetadataFromContext(context,options); const snapshot=getData(); const blob=new Blob([JSON.stringify(snapshot,null,2)],{type:'application/json'}); const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download=options.fileName||'hbds_saved_model.json'; a.click(); URL.revokeObjectURL(url); return snapshot; }
 function getNodeSize(node){
   return getNodeBodySize(node);


### PR DESCRIPTION
### Motivation
- Satellite sample models failed to render links and to apply the metadata radial layout, and Three.js emitted warnings about `dashSize`/`gapSize` being used with `LineBasicMaterial`.
- The loader needed to accept legacy `hypergraph.relationship` naming so links encoded with the older key are preserved.
- Loading should honor a model's declared layout algorithm (e.g. `radial`) when nodes lack explicit positions so the diagram appears correctly from `index.html`.

### Description
- Only supply `dashSize`/`gapSize` when creating a dashed/dotted material by building `materialOptions` conditionally and choosing between `THREE.LineDashedMaterial` and `THREE.LineBasicMaterial`, avoiding invalid properties on `LineBasicMaterial` (`js/hbds_class_link.js`).
- Support legacy relationship keys by reading `hypergraph.relationships` or `hypergraph.relationship` (singular) and mapping them into `hypergraph.link` during normalization so links in `satellite_world_simple_structure.json` are restored (`js/hbds_model.js`).
- Enhance `loadAndRenderScene` to auto-run layout optimization when the model metadata specifies a non-`none` layout algorithm and nodes do not already have valid `position` coordinates, which applies radial/grid/hierarchy layouts on load (`js/hbds_model.js`).

### Testing
- Ran the satellite model validator with `python models/validate_satellite_models.py` which reported both satellite models as `OK`.
- Ran the Java test suite with `mvn test -q` and the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c4119e5d88331b9a51da99558a42a)