### PR TITLE
Fix link geometry recreation to restore link rendering

### DIFF
--- a/js/hbds_class_link.js
+++ b/js/hbds_class_link.js
@@ -121,7 +121,7 @@ export function recalculateAllLinks() {
       });
       separateLinkLabel(route, occupiedLabels, link.linkData.rendering ?? {});
 
-      link.line.geometry.setFromPoints(route.points);
+      replaceLineGeometry(link.line, route.points);
       link.line.userData.baseRoutePoints = route.basePoints.map(point => point.clone());
       link.line.userData.relationshipPorts = {
         sourceSide: portPair.source.side,
@@ -142,6 +142,14 @@ export function recalculateAllLinks() {
       }
     });
   }
+}
+
+function replaceLineGeometry(line, points) {
+  const nextGeometry = new THREE.BufferGeometry().setFromPoints(points);
+  if (line.geometry) {
+    line.geometry.dispose();
+  }
+  line.geometry = nextGeometry;
 }
 
 function createRelationshipPortMarker(kind, rendering = {}) {


### PR DESCRIPTION
### Motivation
- Recreate link geometries to avoid `THREE.BufferGeometry` size mismatches that cause the `Buffer size too small for points data` warning and make links invisible in diagrams like `satellite_world_simple_structure.json`.

### Description
- Replace in-place `line.geometry.setFromPoints(...)` calls with a new helper `replaceLineGeometry(line, points)` that disposes the old geometry and assigns a freshly sized `THREE.BufferGeometry` in `js/hbds_class_link.js`.

### Testing
- Ran `node --check js/hbds_class_link.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c441fea188331af5a5981b3f5001c)