### PR TITLE
Add fallback to ./icons/empty.PNG when icon files are missing

### DIFF
--- a/js/hbds_class.js
+++ b/js/hbds_class.js
@@ -3,6 +3,7 @@ import * as THREE from 'three';
 import {CSS2DObject} from 'three/addons/renderers/CSS2DRenderer.js';
 
 const ICON_EXTENSIONS = ['png', 'svg', 'jpg', 'jpeg', 'webp', 'gif'];
+const DEFAULT_EMPTY_ICON_PATH = './icons/empty.PNG';
 
 /* ─────────────────────────────── Loader ──────────────────────────────── */
 export const Loader = {
@@ -276,7 +277,6 @@ export function createIconTitleLabel(classData, options = {}) {
 
 function installOptionalIcon(label, labelObj, classData, options) {
     const candidates = getIconCandidatePaths(classData);
-    if (!candidates.length) return;
     const name = classData?.name ?? '';
     const estimatedTitleWidth = Math.max(130, String(name).length * 14 + (options.iconSize ? options.iconSize * 20 : 38));
 
@@ -407,6 +407,7 @@ function getIconCandidatePaths(classData) {
             paths.push(path);
         }
     }
+    if (!seen.has(DEFAULT_EMPTY_ICON_PATH)) paths.push(DEFAULT_EMPTY_ICON_PATH);
     return paths;
 }
 

--- a/js/test_dynamic_hbds_layout.js
+++ b/js/test_dynamic_hbds_layout.js
@@ -73,6 +73,7 @@ const HYPER_COLORS = [
 const ATTRIBUTE_NAMES = ['status', 'owner', 'priority', 'version', 'region', 'createdAt', 'score', 'policy'];
 const LINK_NAMES = ['depends on', 'feeds', 'validates', 'routes to', 'owns', 'syncs'];
 const ICON_EXTENSIONS = ['png', 'svg', 'jpg', 'jpeg', 'webp', 'gif'];
+const DEFAULT_EMPTY_ICON_PATH = './icons/empty.PNG';
 const TEST_MODEL_ROOT = 'test_models/';
 const TEST_MODEL_MANIFEST = 'test_models/test_models_manifest.json';
 const TEST_MODEL_HIDDEN_VALUES = [
@@ -764,6 +765,7 @@ function iconCandidatePaths(model) {
       paths.push(path);
     }
   }
+  if (!seen.has(DEFAULT_EMPTY_ICON_PATH)) paths.push(DEFAULT_EMPTY_ICON_PATH);
   return paths;
 }
 


### PR DESCRIPTION
### Motivation
- Ensure class/hyperclass labels still render an icon when no explicit SVG/PNG (or other supported extension) is found by providing a guaranteed default fallback.

### Description
- Add `DEFAULT_EMPTY_ICON_PATH = './icons/empty.PNG'` to `js/hbds_class.js` and `js/test_dynamic_hbds_layout.js`.
- Append `DEFAULT_EMPTY_ICON_PATH` to the list returned by `getIconCandidatePaths` / `iconCandidatePaths` so the lookup always includes the default fallback.
- Remove the early return on empty candidate lists in `installOptionalIcon` so the fallback can be attempted and loaded.

### Testing
- Ran `git status --short` which reported the modified files and succeeded.
- Ran `git add` and `git commit -m "Add default empty icon fallback when icon files are missing"` which completed successfully.
- Created the PR metadata via the `make_pr` helper; no automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca4025a4c8331a7e12e6841c88af3)