### PR TITLE
Avoid icon 404 spam when falling back to empty icon

### DIFF
--- a/js/hbds_class.js
+++ b/js/hbds_class.js
@@ -4,6 +4,27 @@ import {CSS2DObject} from 'three/addons/renderers/CSS2DRenderer.js';
 
 const ICON_EXTENSIONS = ['png', 'svg', 'jpg', 'jpeg', 'webp', 'gif'];
 const DEFAULT_EMPTY_ICON_PATH = './icons/empty.PNG';
+const iconExistenceCache = new Map();
+
+async function iconPathExists(path) {
+    if (!path) return false;
+    if (path === DEFAULT_EMPTY_ICON_PATH) return true;
+    if (iconExistenceCache.has(path)) return iconExistenceCache.get(path);
+
+    const existsPromise = fetch(path, {method: 'HEAD'})
+        .then(response => response.ok)
+        .catch(() => false);
+    iconExistenceCache.set(path, existsPromise);
+    return existsPromise;
+}
+
+async function resolveIconPath(candidates) {
+    for (const candidate of candidates) {
+        if (candidate === DEFAULT_EMPTY_ICON_PATH) return candidate;
+        if (await iconPathExists(candidate)) return candidate;
+    }
+    return DEFAULT_EMPTY_ICON_PATH;
+}
 
 /* ─────────────────────────────── Loader ──────────────────────────────── */
 export const Loader = {
@@ -281,11 +302,6 @@ function installOptionalIcon(label, labelObj, classData, options) {
     const estimatedTitleWidth = Math.max(130, String(name).length * 14 + (options.iconSize ? options.iconSize * 20 : 38));
 
     const img = new Image();
-    let index = 0;
-    const tryNext = () => {
-        if (index >= candidates.length) return;
-        img.src = candidates[index++];
-    };
 
     img.onload = () => {
         const icon = img.cloneNode(false);
@@ -346,8 +362,12 @@ function installOptionalIcon(label, labelObj, classData, options) {
         if (options.iconPosition) labelObj.position.copy(options.iconPosition);
         options.onIconLoaded?.(labelObj, label);
     };
-    img.onerror = tryNext;
-    tryNext();
+    img.onerror = () => {
+        if (img.src !== DEFAULT_EMPTY_ICON_PATH) img.src = DEFAULT_EMPTY_ICON_PATH;
+    };
+    resolveIconPath(candidates).then((resolvedPath) => {
+        img.src = resolvedPath;
+    });
 }
 
 function getTransparentPngSource(image) {


### PR DESCRIPTION
### Motivation
- Prevent repeated browser 404 errors and console noise when icon candidate paths are missing by resolving a valid icon path before setting an image `src`.

### Description
- Added an async in-memory cache `iconExistenceCache` and helper `iconPathExists(path)` that performs `HEAD` checks to test candidate icon URLs.
- Added `resolveIconPath(candidates)` which returns the first existing candidate or the `DEFAULT_EMPTY_ICON_PATH` fallback (`./icons/empty.PNG`).
- Updated `installOptionalIcon` to resolve the icon path first and then assign `img.src`, and retained an `img.onerror` guard that falls back to `DEFAULT_EMPTY_ICON_PATH` if the resolved image fails at runtime.
- All changes are localized to `js/hbds_class.js` and preserve existing transparent-PNG post-processing logic.

### Testing
- Ran `node --check js/hbds_class.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca861ffe483318aeb6625deec0e92)