### PR TITLE
Prevent repeated 404s for missing icons and harden icon fallback

### DIFF
--- a/js/hbds_class.js
+++ b/js/hbds_class.js
@@ -8,7 +8,6 @@ const iconExistenceCache = new Map();
 
 async function iconPathExists(path) {
     if (!path) return false;
-    if (path === DEFAULT_EMPTY_ICON_PATH) return true;
     if (iconExistenceCache.has(path)) return iconExistenceCache.get(path);
 
     const existsPromise = fetch(path, {method: 'HEAD'})
@@ -20,10 +19,9 @@ async function iconPathExists(path) {
 
 async function resolveIconPath(candidates) {
     for (const candidate of candidates) {
-        if (candidate === DEFAULT_EMPTY_ICON_PATH) return candidate;
         if (await iconPathExists(candidate)) return candidate;
     }
-    return DEFAULT_EMPTY_ICON_PATH;
+    return null;
 }
 
 /* ─────────────────────────────── Loader ──────────────────────────────── */
@@ -363,9 +361,14 @@ function installOptionalIcon(label, labelObj, classData, options) {
         options.onIconLoaded?.(labelObj, label);
     };
     img.onerror = () => {
-        if (img.src !== DEFAULT_EMPTY_ICON_PATH) img.src = DEFAULT_EMPTY_ICON_PATH;
+        if (img.dataset.fallbackAttempted === 'true') return;
+        img.dataset.fallbackAttempted = 'true';
+        iconPathExists(DEFAULT_EMPTY_ICON_PATH).then((exists) => {
+            if (exists && img.src !== DEFAULT_EMPTY_ICON_PATH) img.src = DEFAULT_EMPTY_ICON_PATH;
+        });
     };
     resolveIconPath(candidates).then((resolvedPath) => {
+        if (!resolvedPath) return;
         img.src = resolvedPath;
     });
 }


### PR DESCRIPTION
### Motivation
- The icon loader previously forced the empty-icon fallback unconditionally which caused repeated failed requests and 404 spam when that fallback was missing.
- The change aims to avoid noisy network retries and leave labels as text-only when no valid icon is available.

### Description
- Updated `resolveIconPath` to return `null` when no candidate actually exists instead of always returning `DEFAULT_EMPTY_ICON_PATH` so no needless request is made when there is no valid icon.
- Removed the special-case short-circuit that treated `DEFAULT_EMPTY_ICON_PATH` as always present in `iconPathExists` so presence checks are real `HEAD` requests.
- Hardened image error handling in `installOptionalIcon` to attempt the empty-icon fallback at most once using `img.dataset.fallbackAttempted` and only if `iconPathExists(DEFAULT_EMPTY_ICON_PATH)` confirms it exists.
- Guarded async icon assignment so `img.src` is only set when `resolveIconPath` returns a non-null `resolvedPath`, leaving the label text-only otherwise (prevents repeated 404 loops).

### Testing
- Ran `node --check js/hbds_class.js` which completed successfully.
- Attempted `node js/test_dynamic_hbds_layout.js` which failed in this environment due to a missing dependency (`three` package) and not because of the icon changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0caf1838a08331a1732d16d0ea1f89)