### PR TITLE
Add scenario suite runner, status helpers, and UI placeholders; fix icon path

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,21 +16,7 @@
     <div class="control-group">
         <label for="model-select">Select HDBS Model</label>
         <select id="model-select">
-            <option value="models/human.json">human</option>
-            <option value="models/human_and_car.json">human_and_car</option>
-            <option value="models/human_and_car_and_more.json">human and car and more</option>
-            <option value="models/transportation.json">transportation</option>
-            <option value="models/transportation_links.json">transportation and links</option>
-            <option value="models/multimodal_transportation_diagram.json">multimodal transportation diagram</option>
-            <option value="models/human_and_car_links.json">human and car links</option>
-            <option value="models/bridge_road_links.json">bridge road links</option>
-            <option value="models/hyperclass_mail_Carrier.json">Hyperclass Mail Carrier</option>
-            <option value="models/hyperclass_mail_Carrier_with_links.json">Hyperclass Mail Carrier with links</option>
-            <option value="models/complex_hyperclass_mail_Carrier_with_links.json">Complex Hyperclass Mail Carrier with links</option>
-            <option value="models/satellite_world_compact_structure.json">satellite world compact structure</option>
-            <option value="models/satellite_world_complete_structure.json">satellite world complete structure</option>
-            <option value="models/opera_de Paris.json">opera_de Paris</option>
-            <option value="models/TGV.json">TGV</option>
+            <option value="">Loading models...</option>
         </select>
     </div>
     <div class="control-group">

--- a/js/test_dynamic_hbds_layout.js
+++ b/js/test_dynamic_hbds_layout.js
@@ -73,7 +73,7 @@ const HYPER_COLORS = [
 const ATTRIBUTE_NAMES = ['status', 'owner', 'priority', 'version', 'region', 'createdAt', 'score', 'policy'];
 const LINK_NAMES = ['depends on', 'feeds', 'validates', 'routes to', 'owns', 'syncs'];
 const ICON_EXTENSIONS = ['png', 'svg', 'jpg', 'jpeg', 'webp', 'gif'];
-const DEFAULT_EMPTY_ICON_PATH = './icons/empty.PNG';
+const DEFAULT_EMPTY_ICON_PATH = './icons/empty.png';
 const TEST_MODEL_ROOT = 'test_models/';
 const TEST_MODEL_MANIFEST = 'test_models/test_models_manifest.json';
 const TEST_MODEL_HIDDEN_VALUES = [
@@ -347,6 +347,27 @@ function updateStats() {
   $('stat-attribute-count').textContent = String(countAttributes());
   $('stat-hyperclass-count').textContent = String(nodes().filter(node => node.type === 'hyperclass').length);
   document.body.classList.toggle('has-model', nodeCount > 0);
+}
+
+function getCurrentStats() {
+  const allNodes = nodes();
+  return {
+    nodes: allNodes.length,
+    classes: allNodes.filter(node => node.type !== 'hyperclass').length,
+    hyperclasses: allNodes.filter(node => node.type === 'hyperclass').length,
+    links: links().length,
+    attributes: countAttributes()
+  };
+}
+
+function setStatus(message, tone = 'ok') {
+  const status = $('validation-status');
+  if (!status) return;
+  status.className = 'status-chip';
+  if (tone === 'ok' || tone === 'warn' || tone === 'error') {
+    status.classList.add(tone);
+  }
+  status.textContent = message;
 }
 
 function updateValidationStatus() {
@@ -1499,6 +1520,60 @@ async function handleLoadModel() {
   });
 }
 
+async function runScenarioSuite() {
+  if (!availableModels.length) {
+    setStatus('No test models available', 'warn');
+    return;
+  }
+  const suiteButton = $('run-scenario-suite-button');
+  if (suiteButton) suiteButton.disabled = true;
+  const previousValue = $('test-model-select').value;
+  const failures = [];
+  let passed = 0;
+  addLog(`Scenario suite started (${availableModels.length} models)`);
+
+  for (const item of availableModels) {
+    try {
+      const loadedModel = await loadAndRenderScene(item.value, ctx(), {
+        allowedBasePath: TEST_MODEL_ROOT,
+        defaultBasePath: TEST_MODEL_ROOT
+      });
+      const stats = getCurrentStats();
+      const validation = validateData(getData());
+      if (!validation.valid) {
+        failures.push(`${item.label || item.value}: ${validation.errors.join('; ')}`);
+        continue;
+      }
+      if (stats.classes + stats.hyperclasses <= 0) {
+        failures.push(`${item.label || item.value}: rendered no class-like elements`);
+        continue;
+      }
+      const algorithm = getLayoutAlgorithm();
+      if (algorithm !== 'none') {
+        await optimizeAndRefreshLayout(ctx(), { algorithm });
+      }
+      if (!hasFitMetadata(loadedModel)) fitModelToCanvas(ctx(), { padding: 1.15, updateOverview: true });
+      passed += 1;
+    } catch (error) {
+      failures.push(`${item.label || item.value}: ${error?.message || String(error)}`);
+    }
+  }
+
+  $('test-model-select').value = previousValue;
+  updateModelSummary();
+  if (previousValue) await handleLoadModel();
+  if (suiteButton) suiteButton.disabled = false;
+
+  if (failures.length) {
+    addLog(`Scenario suite failed (${passed}/${availableModels.length} passed)`);
+    setStatus(`Scenario suite: ${passed}/${availableModels.length} passed`, 'warn');
+    failures.forEach(failure => addLog(`Scenario failure: ${failure}`));
+  } else {
+    addLog(`Scenario suite passed (${passed}/${availableModels.length})`);
+    setStatus(`Scenario suite: ${passed}/${availableModels.length} passed`, 'ok');
+  }
+}
+
 function clearLinkBuilder() {
   selectedLinkSourceId = null;
   selectedLinkTargetId = null;
@@ -1666,6 +1741,7 @@ function bindUi() {
   $('seed-demo-button').addEventListener('click', () => runAction(handleSeedDemo));
   $('empty-seed-demo-button').addEventListener('click', () => runAction(handleSeedDemo));
   $('load-model-button').addEventListener('click', () => runAction(handleLoadModel));
+  $('run-scenario-suite-button').addEventListener('click', () => runAction(runScenarioSuite));
   $('clear-link-button').addEventListener('click', clearLinkBuilder);
   $('link-pick-button').addEventListener('click', handleLinkPickButton);
   $('selected-color-input')?.addEventListener('input', event => runAction(() => handleSelectedColorChange(event)));

--- a/test_dynamic_hbds_layout.html
+++ b/test_dynamic_hbds_layout.html
@@ -636,6 +636,7 @@
         <button id="load-model-button" type="button">Load</button>
         <button id="seed-demo-button" type="button">Seed Sample</button>
       </div>
+      <button id="run-scenario-suite-button" type="button" class="quiet">Run Scenario Suite</button>
     </section>
 
     <section class="control-group">


### PR DESCRIPTION
### Motivation
- Replace the hard-coded model options with a loading placeholder so model lists can be populated dynamically.  
- Provide a way to automatically exercise and validate the bundled test models via a scenario suite to catch rendering/validation/layout regressions.  
- Improve status reporting and stats collection in the test UI and fix an incorrect icon filename extension.

### Description
- Replaced the static model `<option>` entries in `index.html` with a single `Loading models...` placeholder.  
- Added a `Run Scenario Suite` button to `test_dynamic_hbds_layout.html` and wired it to the UI.  
- Updated `js/test_dynamic_hbds_layout.js` to change `DEFAULT_EMPTY_ICON_PATH` to `./icons/empty.png`, and added `getCurrentStats()` and `setStatus()` helper functions.  
- Implemented `runScenarioSuite()` to iterate `availableModels`, `loadAndRenderScene()` each model, validate with `validateData()`, optionally optimize layout and fit the model, and log/pass/fail results; the button is bound in `bindUi()`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0df42fe4fc8331996e627bcdb47baa)