### PR TITLE
Manifest-based model loading, status/validation UI, keyboard help, and manifest tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,25 @@ Navigation:
 
 ## Models
 
-Models live in the `models/` directory as JSON files. The main page currently lists its available models in `index.html`; the helper `models/models_manifest.json` is available for pages or tools that want manifest-based model discovery.
+Models live in the `models/` directory as JSON files. The main page discovers its models from `models/models_manifest.json` at runtime.
 
 When adding a new model for the main simulator:
 
 1. Add the JSON file under `models/`.
-2. Add an `<option>` for it in the `model-select` dropdown in `index.html`.
+2. Add an entry to `models/models_manifest.json`.
 3. Serve the app locally and verify the model loads.
+
+You can validate model manifest integrity with:
+
+```sh
+python3 tools/validate_manifests.py
+```
+
+You can lint naming consistency (HBDS/HDBS labels, spaced values, missing files) with:
+
+```sh
+python3 tools/lint_model_naming.py
+```
 
 ## Project Structure
 

--- a/css/style.css
+++ b/css/style.css
@@ -40,6 +40,60 @@ canvas {
   gap: 8px;
 }
 
+.status-chip {
+  min-height: 28px;
+  border: 1px solid #d5dbe3;
+  border-radius: 6px;
+  background: #fff;
+  color: #475569;
+  font-size: 12px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 8px;
+}
+
+.status-chip.ok { border-color: #b7e4c7; color: #087443; background: #f1fbf5; }
+.status-chip.warn { border-color: #f7d89d; color: #a15c07; background: #fff8e8; }
+.status-chip.error { border-color: #f3b8b0; color: #b42318; background: #fff5f3; }
+
+.status-note {
+  font-size: 12px;
+  color: #64748b;
+}
+
+.help-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  background: rgba(15, 23, 42, 0.42);
+  display: grid;
+  place-items: center;
+}
+
+.help-overlay[hidden] {
+  display: none !important;
+}
+
+.help-card {
+  width: min(460px, calc(100% - 28px));
+  border-radius: 8px;
+  border: 1px solid #cbd5e1;
+  background: #fff;
+  padding: 14px;
+  box-shadow: 0 12px 26px rgba(0, 0, 0, .2);
+}
+
+.help-card kbd {
+  border: 1px solid #94a3b8;
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 12px;
+  background: #f8fafc;
+}
+
 .control-group label {
   font-weight: 600;
   font-size: 14px;

--- a/index.html
+++ b/index.html
@@ -14,24 +14,15 @@
 </div>
 <div id="controls-panel">
     <div class="control-group">
-        <label for="model-select">Select HDBS Model</label>
+        <div id="load-status" class="status-chip" aria-live="polite">Load status: idle</div>
+        <div id="validation-status-main" class="status-chip" aria-live="polite">Validation: pending</div>
+    </div>
+    <div class="control-group">
+        <label for="model-select">Select HBDS Model</label>
         <select id="model-select">
-            <option value="models/human.json">human</option>
-            <option value="models/human_and_car.json">human_and_car</option>
-            <option value="models/human_and_car_and_more.json">human and car and more</option>
-            <option value="models/transportation.json">transportation</option>
-            <option value="models/transportation_links.json">transportation and links</option>
-            <option value="models/multimodal_transportation_diagram.json">multimodal transportation diagram</option>
-            <option value="models/human_and_car_links.json">human and car links</option>
-            <option value="models/bridge_road_links.json">bridge road links</option>
-            <option value="models/hyperclass_mail_Carrier.json">Hyperclass Mail Carrier</option>
-            <option value="models/hyperclass_mail_Carrier_with_links.json">Hyperclass Mail Carrier with links</option>
-            <option value="models/complex_hyperclass_mail_Carrier_with_links.json">Complex Hyperclass Mail Carrier with links</option>
-            <option value="models/satellite_world_compact_structure.json">satellite world compact structure</option>
-            <option value="models/satellite_world_complete_structure.json">satellite world complete structure</option>
-            <option value="models/opera_de Paris.json">opera_de Paris</option>
-            <option value="models/TGV.json">TGV</option>
+            <option value="">Loading models...</option>
         </select>
+        <div id="model-select-diagnostics" class="status-note">Loading model manifest…</div>
     </div>
     <div class="control-group">
         <label class="checkbox-wrapper" for="view-toggle">
@@ -87,6 +78,22 @@
     </div>
     <div class="control-group">
         <button id="fit-model-button">Fit Model</button>
+        <button id="help-shortcuts-button" type="button">Keyboard Help</button>
+    </div>
+</div>
+<div id="keyboard-help" class="help-overlay" hidden role="dialog" aria-modal="true" aria-labelledby="help-title">
+    <div class="help-card">
+        <h2 id="help-title">Keyboard Shortcuts</h2>
+        <ul>
+            <li><kbd>H</kbd> Toggle this help</li>
+            <li><kbd>F</kbd> Fit model</li>
+            <li><kbd>O</kbd> Optimize layout</li>
+            <li><kbd>S</kbd> Save model</li>
+            <li><kbd>V</kbd> Toggle 2D/3D view</li>
+            <li><kbd>Esc</kbd> Close help</li>
+        </ul>
+        <p class="status-note">Focus order: model selector → view/edit toggles → actions → settings.</p>
+        <button id="close-help-button" type="button">Close</button>
     </div>
 </div>
 <script type="importmap">
@@ -116,6 +123,7 @@
     const draggableObjects = [];
     let lightingState = normalizeSceneSettings();
     let sceneLights = {};
+    let modelsLoadOk = false;
 
     /* ---------- MAIN APPLICATION ---------- */
     async function init() {
@@ -175,21 +183,7 @@
         });
         bindSceneSettingsControls();
         document.getElementById('model-select').addEventListener('change', async e => {
-            const loadedModel = await loadAndRenderScene(e.target.value, getModelContext(), {
-                allowedBasePath: 'models/'
-            });
-            const preserveLayout = Boolean(loadedModel?.metadata?.preserveLayout || loadedModel?.hypergraph?.metadata?.preserveLayout);
-            const algorithm = document.getElementById('layout-algorithm-select').value;
-            let didOptimize = false;
-            if (!preserveLayout && document.getElementById('auto-optimize-toggle').checked && algorithm !== 'none') {
-                await optimizeAndRefreshLayout(getModelContext(), {
-                    algorithm
-                });
-                didOptimize = true;
-            }
-            if (didOptimize || !hasFitMetadata(loadedModel)) {
-                fitModelToCanvas(getModelContext(), { padding: 1.15, updateOverview: true });
-            }
+            await loadSelectedModel(e.target.value);
         });
         document.getElementById('fit-model-button').addEventListener('click', () => {
             fitModelToCanvas(getModelContext(), { padding: 1.15, updateOverview: true });
@@ -200,13 +194,8 @@
         initModelOverview(getModelContext());
         await populateModelSelect();
         const initialModel = document.getElementById('model-select').value;
-        loadAndRenderScene(initialModel, getModelContext(), {
-            allowedBasePath: 'models/'
-        }).then(loadedModel => {
-            if (!hasFitMetadata(loadedModel)) {
-                fitModelToCanvas(getModelContext(), { padding: 1.15, updateOverview: true });
-            }
-        });
+        if (initialModel) await loadSelectedModel(initialModel);
+        bindKeyboardShortcuts();
     }
 
     function hasFitMetadata(model) {
@@ -216,23 +205,104 @@
 
     async function populateModelSelect() {
         const select = document.getElementById('model-select');
+        const diagnostics = document.getElementById('model-select-diagnostics');
         const selectedValue = select.value;
-        const models = await listAvailableModels({
-            manifestPath: 'models/models_manifest.json',
-            modelsPath: 'models/'
-        });
-        if (!models.length) return;
+        try {
+            const models = await listAvailableModels({
+                manifestPath: 'models/models_manifest.json',
+                modelsPath: 'models/'
+            });
+            if (!models.length) {
+                setLoadStatus('Load status: no models found', 'warn');
+                diagnostics.textContent = 'Manifest loaded but no usable models were found.';
+                select.innerHTML = '<option value="">No models available</option>';
+                modelsLoadOk = false;
+                return;
+            }
 
-        select.innerHTML = '';
-        models.forEach(model => {
-            const option = document.createElement('option');
-            option.value = model.value;
-            option.textContent = model.label || model.value;
-            select.appendChild(option);
+            select.innerHTML = '';
+            models.forEach(model => {
+                const option = document.createElement('option');
+                option.value = model.value;
+                option.textContent = model.label || model.value;
+                select.appendChild(option);
+            });
+            select.value = models.some(model => model.value === selectedValue)
+                ? selectedValue
+                : models[0].value;
+            diagnostics.textContent = `Loaded ${models.length} models from manifest.`;
+            setLoadStatus('Load status: manifest loaded', 'ok');
+            modelsLoadOk = true;
+        } catch (error) {
+            select.innerHTML = '<option value="">Failed to load models</option>';
+            diagnostics.textContent = `Manifest error: ${error?.message || String(error)}`;
+            setLoadStatus('Load status: manifest error', 'error');
+            modelsLoadOk = false;
+        }
+    }
+
+    async function loadSelectedModel(modelPath) {
+        if (!modelPath) return;
+        setLoadStatus(`Load status: loading ${modelPath}`, 'warn');
+        try {
+            const loadedModel = await loadAndRenderScene(modelPath, getModelContext(), { allowedBasePath: 'models/' });
+            const validation = validateLoadedModel(loadedModel);
+            setValidationStatus(validation.message, validation.tone);
+            const preserveLayout = Boolean(loadedModel?.metadata?.preserveLayout || loadedModel?.hypergraph?.metadata?.preserveLayout);
+            const algorithm = document.getElementById('layout-algorithm-select').value;
+            let didOptimize = false;
+            if (!preserveLayout && document.getElementById('auto-optimize-toggle').checked && algorithm !== 'none') {
+                await optimizeAndRefreshLayout(getModelContext(), { algorithm });
+                didOptimize = true;
+            }
+            if (didOptimize || !hasFitMetadata(loadedModel)) {
+                fitModelToCanvas(getModelContext(), { padding: 1.15, updateOverview: true });
+            }
+            setLoadStatus(`Load status: loaded ${modelPath}`, 'ok');
+        } catch (error) {
+            setLoadStatus(`Load status: failed ${modelPath}`, 'error');
+            setValidationStatus(`Validation: load error (${error?.message || String(error)})`, 'error');
+        }
+    }
+
+    function validateLoadedModel(model) {
+        const classes = Array.isArray(model?.hypergraph?.class) ? model.hypergraph.class.length : 0;
+        const links = Array.isArray(model?.hypergraph?.link) ? model.hypergraph.link.length : 0;
+        if (classes <= 0) return { message: 'Validation: warning (no classes)', tone: 'warn' };
+        const dangling = (model?.hypergraph?.link || []).filter(link => !link?.sourceClassId || !link?.targetClassId).length;
+        if (dangling > 0) return { message: `Validation: warning (${dangling} incomplete links)`, tone: 'warn' };
+        return { message: `Validation: ok (${classes} classes, ${links} links)`, tone: 'ok' };
+    }
+
+    function setLoadStatus(message, tone) { setStatusChip('load-status', message, tone); }
+    function setValidationStatus(message, tone) { setStatusChip('validation-status-main', message, tone); }
+    function setStatusChip(id, message, tone = 'ok') {
+        const chip = document.getElementById(id);
+        if (!chip) return;
+        chip.className = 'status-chip';
+        if (['ok', 'warn', 'error'].includes(tone)) chip.classList.add(tone);
+        chip.textContent = message;
+    }
+
+    function toggleHelpOverlay(show) {
+        const overlay = document.getElementById('keyboard-help');
+        if (!overlay) return;
+        overlay.hidden = !show;
+        if (show) document.getElementById('close-help-button')?.focus();
+        else document.getElementById('help-shortcuts-button')?.focus();
+    }
+
+    function bindKeyboardShortcuts() {
+        window.addEventListener('keydown', event => {
+            if (event.key === 'Escape') return toggleHelpOverlay(false);
+            if (event.target && ['INPUT', 'SELECT', 'TEXTAREA'].includes(event.target.tagName)) return;
+            if (event.key.toLowerCase() === 'h') return toggleHelpOverlay(true);
+            if (event.key.toLowerCase() === 'f') return document.getElementById('fit-model-button')?.click();
+            if (event.key.toLowerCase() === 'o') return document.getElementById('optimize-layout-button')?.click();
+            if (event.key.toLowerCase() === 's') return document.getElementById('save-model-button')?.click();
+            if (event.key.toLowerCase() === 'v') return document.getElementById('view-toggle')?.click();
         });
-        select.value = models.some(model => model.value === selectedValue)
-            ? selectedValue
-            : models[0].value;
+        if (!modelsLoadOk) setValidationStatus('Validation: pending (manifest not ready)', 'warn');
     }
 
 
@@ -503,3 +573,9 @@
 </script>
 </body>
 </html>
+        const shortcutsButton = document.getElementById('help-shortcuts-button');
+        shortcutsButton.addEventListener('click', () => toggleHelpOverlay(true));
+        document.getElementById('close-help-button').addEventListener('click', () => toggleHelpOverlay(false));
+        document.getElementById('keyboard-help').addEventListener('click', event => {
+            if (event.target?.id === 'keyboard-help') toggleHelpOverlay(false);
+        });

--- a/js/hbds_model.js
+++ b/js/hbds_model.js
@@ -42,6 +42,15 @@ export const getData=()=>data;
 export function normalizeData(inputData){
   const m=clone(inputData||{}); m.hypergraph=m.hypergraph||{};
   m.metadata=normalizeModelMetadata({ ...(m.hypergraph.metadata||{}), ...(m.metadata||{}) });
+  const legacyRelationships=Array.isArray(m.hypergraph.relationships)
+    ? m.hypergraph.relationships
+    : (Array.isArray(m.hypergraph.relationship)?m.hypergraph.relationship:[]);
+  const normalizedLegacyLinks=legacyRelationships.map(rel=>({
+    ...rel,
+    sourceClassId:rel.sourceClassId??rel.source,
+    targetClassId:rel.targetClassId??rel.target,
+    name:rel.name||rel.label||''
+  }));
   if(Array.isArray(m.hypergraph.hyperclass) && (!Array.isArray(m.hypergraph.class) || m.hypergraph.class.length===0)){
     const flattened=[];
     for(const rawHyperclass of m.hypergraph.hyperclass){
@@ -58,20 +67,14 @@ export function normalizeData(inputData){
     }
     if(Array.isArray(m.hypergraph.class)) flattened.push(...m.hypergraph.class);
     m.hypergraph.class=flattened;
-    const legacyRelationships=Array.isArray(m.hypergraph.relationships)
-      ? m.hypergraph.relationships
-      : (Array.isArray(m.hypergraph.relationship)?m.hypergraph.relationship:[]);
-    m.hypergraph.link=legacyRelationships.length
-      ? legacyRelationships.map(rel=>({
-          ...rel,
-          sourceClassId:rel.sourceClassId??rel.source,
-          targetClassId:rel.targetClassId??rel.target,
-          name:rel.name||rel.label||''
-        }))
+    m.hypergraph.link=normalizedLegacyLinks.length
+      ? normalizedLegacyLinks
       : (Array.isArray(m.hypergraph.link)?m.hypergraph.link:[]);
   }
   m.hypergraph.class=Array.isArray(m.hypergraph.class)?m.hypergraph.class:[];
-  m.hypergraph.link=Array.isArray(m.hypergraph.link)?m.hypergraph.link:[];
+  m.hypergraph.link=normalizedLegacyLinks.length
+    ? normalizedLegacyLinks
+    : (Array.isArray(m.hypergraph.link)?m.hypergraph.link:[]);
   const ids=new Set(); const byId=new Map();
   m.hypergraph.class=m.hypergraph.class.map((n,i)=>{let x=clone(n||{}); if(x.type==='hyperclass') x=normalizeHyperclassData(x); else x=normalizeClassData(x); x.id=x.id??nextId('node'); while(ids.has(x.id)) x.id=nextId('node'); ids.add(x.id); x.name=x.name||`Node ${i+1}`; x.attributes=Array.isArray(x.attributes)?x.attributes:[]; if(x.type==='hyperclass') x.children=Array.isArray(x.children)?x.children:[]; byId.set(x.id,x); return x;});
   for(const n of m.hypergraph.class){ if(n.parentClassId && (!byId.has(n.parentClassId)||byId.get(n.parentClassId).type!=='hyperclass')) n.parentClassId=null; }
@@ -343,7 +346,18 @@ function updateFitMetadataFromContext(context, options = {}) {
   if (!context?.diagramGroup || !context?.camera) return getLayoutSettings();
   const box = new THREE.Box3().setFromObject(context.diagramGroup);
   if (box.isEmpty()) return getLayoutSettings();
-  return saveFitMetadata(calculateFitMetrics(box, context.camera, options)).fit;
+  const fit = calculateFitMetrics(box, context.camera, options);
+  const center = context.orbitControls?.target
+    ? context.orbitControls.target.clone()
+    : box.getCenter(new THREE.Vector3());
+  const cameraDistance = context.camera.position.distanceTo(center);
+  fit.center = {
+    x: roundFitNumber(center.x),
+    y: roundFitNumber(center.y),
+    z: roundFitNumber(center.z)
+  };
+  fit.distance = roundFitNumber(cameraDistance);
+  return saveFitMetadata(fit).fit;
 }
 
 function hasUsableFitSettings(fit) {

--- a/js/test_dynamic_hbds_layout.js
+++ b/js/test_dynamic_hbds_layout.js
@@ -73,7 +73,7 @@ const HYPER_COLORS = [
 const ATTRIBUTE_NAMES = ['status', 'owner', 'priority', 'version', 'region', 'createdAt', 'score', 'policy'];
 const LINK_NAMES = ['depends on', 'feeds', 'validates', 'routes to', 'owns', 'syncs'];
 const ICON_EXTENSIONS = ['png', 'svg', 'jpg', 'jpeg', 'webp', 'gif'];
-const DEFAULT_EMPTY_ICON_PATH = './icons/empty.PNG';
+const DEFAULT_EMPTY_ICON_PATH = './icons/empty.png';
 const TEST_MODEL_ROOT = 'test_models/';
 const TEST_MODEL_MANIFEST = 'test_models/test_models_manifest.json';
 const TEST_MODEL_HIDDEN_VALUES = [
@@ -347,6 +347,27 @@ function updateStats() {
   $('stat-attribute-count').textContent = String(countAttributes());
   $('stat-hyperclass-count').textContent = String(nodes().filter(node => node.type === 'hyperclass').length);
   document.body.classList.toggle('has-model', nodeCount > 0);
+}
+
+function getCurrentStats() {
+  const allNodes = nodes();
+  return {
+    nodes: allNodes.length,
+    classes: allNodes.filter(node => node.type !== 'hyperclass').length,
+    hyperclasses: allNodes.filter(node => node.type === 'hyperclass').length,
+    links: links().length,
+    attributes: countAttributes()
+  };
+}
+
+function setStatus(message, tone = 'ok') {
+  const status = $('scenario-status');
+  if (!status) return;
+  status.className = 'status-chip';
+  if (tone === 'ok' || tone === 'warn' || tone === 'error') {
+    status.classList.add(tone);
+  }
+  status.textContent = message;
 }
 
 function updateValidationStatus() {
@@ -1499,6 +1520,73 @@ async function handleLoadModel() {
   });
 }
 
+async function runScenarioSuite() {
+  if (!availableModels.length) {
+    setStatus('No test models available', 'warn');
+    return;
+  }
+  const suiteButton = $('run-scenario-suite-button');
+  const modelSelect = $('test-model-select');
+  if (suiteButton) suiteButton.disabled = true;
+  if (modelSelect) modelSelect.disabled = true;
+  const previousValue = modelSelect?.value || '';
+  const failures = [];
+  let passed = 0;
+  const startedAt = performance.now();
+  addLog(`Scenario suite started (${availableModels.length} models)`);
+  setStatus(`Running suite: 0/${availableModels.length}`, 'warn');
+
+  try {
+    for (const item of availableModels) {
+      const label = item.label || item.value;
+      try {
+        const loadedModel = await loadAndRenderScene(item.value, ctx(), {
+          allowedBasePath: TEST_MODEL_ROOT,
+          defaultBasePath: TEST_MODEL_ROOT
+        });
+        const stats = getCurrentStats();
+        const validation = validateData(getData());
+        if (!validation.valid) {
+          failures.push(`${label}: ${validation.errors.join('; ')}`);
+          continue;
+        }
+        if (stats.classes + stats.hyperclasses <= 0) {
+          failures.push(`${label}: rendered no class-like elements`);
+          continue;
+        }
+        const algorithm = getLayoutAlgorithm();
+        if (algorithm !== 'none') {
+          await optimizeAndRefreshLayout(ctx(), { algorithm });
+        }
+        if (!hasFitMetadata(loadedModel)) fitModelToCanvas(ctx(), { padding: 1.15, updateOverview: true });
+        passed += 1;
+        setStatus(`Running suite: ${passed}/${availableModels.length}`, 'warn');
+      } catch (error) {
+        failures.push(`${label}: ${error?.message || String(error)}`);
+      }
+    }
+  } finally {
+    if (modelSelect) {
+      const hasPreviousOption = [...modelSelect.options].some(option => option.value === previousValue);
+      modelSelect.value = hasPreviousOption ? previousValue : '';
+      modelSelect.disabled = false;
+    }
+    updateModelSummary();
+    await handleLoadModel();
+    if (suiteButton) suiteButton.disabled = false;
+  }
+
+  const elapsedMs = Math.round(performance.now() - startedAt);
+  if (failures.length) {
+    addLog(`Scenario suite failed (${passed}/${availableModels.length} passed in ${elapsedMs}ms)`);
+    setStatus(`Scenario suite: ${passed}/${availableModels.length} passed`, 'warn');
+    failures.forEach(failure => addLog(`Scenario failure: ${failure}`));
+  } else {
+    addLog(`Scenario suite passed (${passed}/${availableModels.length} in ${elapsedMs}ms)`);
+    setStatus(`Scenario suite: ${passed}/${availableModels.length} passed`, 'ok');
+  }
+}
+
 function clearLinkBuilder() {
   selectedLinkSourceId = null;
   selectedLinkTargetId = null;
@@ -1666,6 +1754,7 @@ function bindUi() {
   $('seed-demo-button').addEventListener('click', () => runAction(handleSeedDemo));
   $('empty-seed-demo-button').addEventListener('click', () => runAction(handleSeedDemo));
   $('load-model-button').addEventListener('click', () => runAction(handleLoadModel));
+  $('run-scenario-suite-button').addEventListener('click', () => runAction(runScenarioSuite));
   $('clear-link-button').addEventListener('click', clearLinkBuilder);
   $('link-pick-button').addEventListener('click', handleLinkPickButton);
   $('selected-color-input')?.addEventListener('input', event => runAction(() => handleSelectedColorChange(event)));

--- a/test_dynamic_hbds_layout.html
+++ b/test_dynamic_hbds_layout.html
@@ -624,6 +624,7 @@
       <div class="stat"><span class="stat-value" id="stat-hyperclass-count">0</span><span class="stat-label">Groups</span></div>
     </div>
     <div id="validation-status" class="status-chip">No model loaded</div>
+    <div id="scenario-status" class="status-chip">Scenario suite idle</div>
 
     <section class="control-group">
       <div class="section-title">Model</div>
@@ -636,6 +637,7 @@
         <button id="load-model-button" type="button">Load</button>
         <button id="seed-demo-button" type="button">Seed Sample</button>
       </div>
+      <button id="run-scenario-suite-button" type="button" class="quiet">Run Scenario Suite</button>
     </section>
 
     <section class="control-group">

--- a/tools/lint_model_naming.py
+++ b/tools/lint_model_naming.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+import re
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_json(path: Path):
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main():
+    manifest = ROOT / "models" / "models_manifest.json"
+    data = load_json(manifest)
+    items = data.get("models", [])
+    warnings = []
+    errors = []
+
+    for idx, item in enumerate(items):
+        value = str(item.get("value", ""))
+        label = str(item.get("label", ""))
+        if " " in value:
+            warnings.append(f"models[{idx}] value contains spaces: {value}")
+        if re.search(r"\bHDBS\b", label, flags=re.IGNORECASE):
+            warnings.append(f"models[{idx}] label uses HDBS; prefer HBDS: {label}")
+        normalized = value if value.endswith(".json") else f"models/{value}.json"
+        path = ROOT / normalized
+        if not path.exists():
+            errors.append(f"models[{idx}] points to missing file: {normalized}")
+
+    if warnings:
+        print("Naming warnings:")
+        for warning in warnings:
+            print(f"- {warning}")
+    if errors:
+        print("Naming errors:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Naming lint passed (warnings may still be present).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/tools/validate_manifests.py
+++ b/tools/validate_manifests.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_json(path: Path):
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def validate_manifest(manifest_path: Path, default_base: str):
+    errors = []
+    data = load_json(manifest_path)
+    items = data.get("models")
+    if not isinstance(items, list):
+        return [f"{manifest_path}: 'models' must be an array"]
+    for idx, item in enumerate(items):
+        if not isinstance(item, dict):
+            errors.append(f"{manifest_path}: models[{idx}] must be an object")
+            continue
+        value = item.get("value")
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"{manifest_path}: models[{idx}].value must be a non-empty string")
+            continue
+        normalized = value if value.endswith(".json") else f"{default_base}{value}.json"
+        model_path = ROOT / normalized
+        if not model_path.exists():
+            errors.append(f"{manifest_path}: models[{idx}] -> missing file {normalized}")
+    return errors
+
+
+def main():
+    checks = [
+        (ROOT / "models" / "models_manifest.json", "models/"),
+        (ROOT / "test_models" / "test_models_manifest.json", "test_models/"),
+    ]
+    all_errors = []
+    for manifest_path, default_base in checks:
+        if not manifest_path.exists():
+            all_errors.append(f"missing manifest: {manifest_path}")
+            continue
+        all_errors.extend(validate_manifest(manifest_path, default_base))
+    if all_errors:
+        print("Manifest validation failed:")
+        for err in all_errors:
+            print(f"- {err}")
+        return 1
+    print("Manifest validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+


### PR DESCRIPTION
### Motivation

- Move model discovery to a runtime manifest and provide clearer feedback about model loading and validation status. 
- Improve robustness for legacy model shapes and metadata so older manifests/relationships still render correctly. 
- Add developer tooling to validate manifests and lint model naming to prevent broken or inconsistent entries. 
- Provide keyboard shortcuts and on-screen help to speed interactive workflows and testing. 

### Description

- Update `README.md` to describe manifest-based discovery and add usage instructions for the new tools `tools/validate_manifests.py` and `tools/lint_model_naming.py`. 
- Replace hard-coded `<option>` entries in `index.html` with runtime manifest loading and add UI status chips (`load-status`, `validation-status-main`), diagnostics, a keyboard help overlay, and related controls and event handlers. 
- Add model-loading helpers and validation to the main script (`loadSelectedModel`, `validateLoadedModel`, `setStatusChip`) and wire model selection to the manifest-driven flow. 
- Extend `js/hbds_model.js` data normalization to accept legacy relationship fields and map them into normalized link objects, and enhance `updateFitMetadataFromContext` to store computed `center` and `distance` values. 
- Add `status-chip` and help-overlay styling in `css/style.css`, fix an icon filename case in `js/test_dynamic_hbds_layout.js`, and add scenario-suite automation and status helpers to the test harness (`runScenarioSuite`, `getCurrentStats`, `setStatus`). 
- Add two new tooling scripts: `tools/validate_manifests.py` to validate manifest entries and referenced files, and `tools/lint_model_naming.py` to check naming consistency and missing files. 

### Testing

- Ran manifest validation via `python3 tools/validate_manifests.py`, which completed without errors against the repository manifests. 
- Ran naming linting via `python3 tools/lint_model_naming.py`, which reported no blocking errors (warnings printed when applicable). 
- Exercised the manifest-driven model loading flow in the development UI to confirm the dropdown populates and the load/validation status chips update (manual dev-server smoke check).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0df42fe4fc8331996e627bcdb47baa)