### PR TITLE
Refine dynamic layout test menu and model-loading UX

### DIFF
--- a/js/test_dynamic_hbds_layout.js
+++ b/js/test_dynamic_hbds_layout.js
@@ -301,7 +301,7 @@ function compactControlSections() {
     if (!title) return;
     const details = document.createElement('details');
     details.className = section.className;
-    if (section.dataset.defaultOpen === 'true' || ['Model', 'Selection'].some(label => title.textContent.includes(label))) {
+    if (section.dataset.defaultOpen === 'true' || title.textContent.includes('Model')) {
       details.open = true;
     }
     const summary = document.createElement('summary');
@@ -351,6 +351,18 @@ function updateStats() {
   $('stat-attribute-count').textContent = String(countAttributes());
   $('stat-hyperclass-count').textContent = String(nodes().filter(node => node.type === 'hyperclass').length);
   document.body.classList.toggle('has-model', nodeCount > 0);
+}
+
+function updateCanvasTitle() {
+  const title = $('canvas-model-title');
+  if (!title) return;
+  const selectedOption = $('test-model-select')?.selectedOptions?.[0];
+  const selectedText = selectedOption?.textContent?.trim();
+  if (nodes().length <= 0) {
+    title.textContent = '';
+    return;
+  }
+  title.textContent = selectedText && selectedText !== 'Blank workspace' ? selectedText : 'Untitled Model';
 }
 
 function getCurrentStats() {
@@ -551,7 +563,6 @@ function updateModeControls() {
   };
 
   disable('add-hyperclass-button', isReadOnly);
-  disable('empty-add-hyperclass-button', isReadOnly);
   disable('add-class-button', isReadOnly);
   disable('add-attribute-button', isReadOnly || structureOnly || !owner);
   disable('add-link-button', isReadOnly || structureOnly || !canCreateLink);
@@ -562,8 +573,6 @@ function updateModeControls() {
   disable('selected-corner-radius-input', isReadOnly || !selected);
   disable('selected-text-color-input', isReadOnly || !selected);
   disable('selected-name-input', isReadOnly || !selected);
-  disable('seed-demo-button', isReadOnly);
-  disable('empty-seed-demo-button', isReadOnly);
   disable('reset-model-button', isReadOnly);
   disable('apply-json-button', isReadOnly);
   disable('link-pick-button', isReadOnly || structureOnly);
@@ -598,6 +607,7 @@ function updateInterface(options = {}) {
   normalizeClassSurfaceMaterials();
   applySelectionHighlight();
   updateModelSummary();
+  updateCanvasTitle();
   if (options.json !== false) updateJsonPreviewFromData();
   updateRenderDiagnostics();
 }
@@ -1487,6 +1497,8 @@ function handleFitModel() {
 
 async function handleResetModel() {
   await resetData({ context: ctx(), refresh: false });
+  applyModelLayoutSettings({ algorithm: 'grid' });
+  setLayoutSettings({ ...getLayoutSettings(), algorithm: 'grid' }, { applyContext: false });
   selectedElementId = null;
   selectedParentHyperclassId = null;
   selectedAttributeOwnerId = null;
@@ -1895,7 +1907,6 @@ function setupDrag() {
 function bindUi() {
   $('add-class-button').addEventListener('click', () => runAction(handleAddClass));
   $('add-hyperclass-button').addEventListener('click', () => runAction(handleAddHyperclass));
-  $('empty-add-hyperclass-button').addEventListener('click', () => runAction(handleAddHyperclass));
   $('add-attribute-button').addEventListener('click', () => runAction(handleAddAttribute));
   $('add-link-button').addEventListener('click', () => runAction(handleAddLink));
   $('delete-selected-button').addEventListener('click', () => runAction(handleDeleteSelected));
@@ -1905,9 +1916,6 @@ function bindUi() {
   $('export-json-button').addEventListener('click', handleExportJson);
   $('apply-json-button').addEventListener('click', () => runAction(handleApplyJson));
   $('reset-model-button').addEventListener('click', () => runAction(handleResetModel));
-  $('seed-demo-button').addEventListener('click', () => runAction(handleSeedDemo));
-  $('empty-seed-demo-button').addEventListener('click', () => runAction(handleSeedDemo));
-  $('load-model-button').addEventListener('click', () => runAction(handleLoadModel));
   $('run-scenario-suite-button').addEventListener('click', () => runAction(runScenarioSuite));
   $('clear-link-button').addEventListener('click', clearLinkBuilder);
   $('link-pick-button').addEventListener('click', handleLinkPickButton);
@@ -2003,6 +2011,8 @@ async function init() {
   installDebugHooks();
   window.addEventListener('resize', resizeRenderers);
 
+  applyModelLayoutSettings({ algorithm: 'grid' });
+  setLayoutSettings({ ...getLayoutSettings(), algorithm: 'grid' }, { applyContext: false });
   await resetData({ context: ctx(), refresh: true });
   initModelOverview(ctx());
   clearOverview();

--- a/test_dynamic_hbds_layout.html
+++ b/test_dynamic_hbds_layout.html
@@ -145,6 +145,30 @@
       display: block;
     }
 
+    #canvas-model-title {
+      position: absolute;
+      top: 14px;
+      left: 16px;
+      z-index: 18;
+      max-width: calc(100% - 32px);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-size: 17px;
+      font-weight: 780;
+      color: #1f2a37;
+      background: rgba(255, 255, 255, 0.74);
+      border: 1px solid rgba(152, 162, 179, 0.35);
+      border-radius: 7px;
+      padding: 5px 10px;
+      backdrop-filter: blur(3px);
+      display: none;
+    }
+
+    body.has-model #canvas-model-title {
+      display: inline-block;
+    }
+
     .label-layer {
       position: absolute;
       inset: 0;
@@ -164,38 +188,6 @@
       box-shadow: 0 0 0 1px rgba(23, 105, 224, 0.35);
     }
 
-    #canvas-empty-state {
-      position: absolute;
-      left: 50%;
-      top: 50%;
-      z-index: 12;
-      width: min(440px, calc(100% - 40px));
-      padding: 18px;
-      border: 1px solid rgba(122, 139, 160, 0.38);
-      border-radius: 8px;
-      background: rgba(255, 255, 255, 0.92);
-      box-shadow: 0 18px 44px rgba(40, 54, 72, 0.12);
-      transform: translate(-50%, -50%);
-    }
-
-    body.has-model #canvas-empty-state {
-      display: none;
-    }
-
-    .empty-title {
-      margin: 0 0 6px;
-      font-size: 20px;
-      line-height: 1.2;
-    }
-
-    .empty-copy {
-      margin: 0 0 14px;
-      color: var(--muted);
-      font-size: 13px;
-      line-height: 1.45;
-    }
-
-    .empty-actions,
     .control-row,
     .two-col {
       display: grid;
@@ -239,15 +231,15 @@
       height: 100%;
       overflow: auto;
       border-left: 1px solid rgba(152, 162, 179, 0.45);
-      background: rgba(251, 252, 254, 0.94);
+      background: linear-gradient(180deg, #f7f9fc 0%, #f2f7fb 100%);
       box-shadow: -18px 0 48px rgba(40, 54, 72, 0.1);
       padding: 16px;
     }
 
     .panel-header {
       display: grid;
-      gap: 8px;
-      margin-bottom: 12px;
+      gap: 4px;
+      margin-bottom: 10px;
     }
 
     .eyebrow {
@@ -258,15 +250,8 @@
 
     h1 {
       margin: 0;
-      font-size: 22px;
+      font-size: 20px;
       line-height: 1.15;
-    }
-
-    .panel-subtitle {
-      margin: 0;
-      color: var(--muted);
-      font-size: 13px;
-      line-height: 1.4;
     }
 
     .stats-grid {
@@ -280,7 +265,7 @@
       min-height: 56px;
       border: 1px solid var(--line);
       border-radius: 8px;
-      background: #ffffff;
+      background: #fdfefe;
       padding: 8px;
     }
 
@@ -306,7 +291,7 @@
       margin-bottom: 10px;
       border: 1px solid var(--line);
       border-radius: 8px;
-      background: #ffffff;
+      background: #fbfdff;
       color: var(--muted);
       font-size: 12px;
       font-weight: 700;
@@ -336,7 +321,7 @@
       margin-bottom: 10px;
       border: 1px solid var(--line);
       border-radius: 8px;
-      background: #ffffff;
+      background: #f9fcff;
       padding: 10px;
     }
 
@@ -430,7 +415,7 @@
     .mode-segment button.active {
       border-color: #c7d7ef;
       color: var(--accent-strong);
-      background: #ffffff;
+      background: #f7fbff;
       box-shadow: 0 1px 3px rgba(40, 54, 72, 0.1);
     }
 
@@ -595,14 +580,7 @@
 </head>
 <body>
   <main id="container">
-    <section id="canvas-empty-state" aria-live="polite">
-      <h2 class="empty-title">Empty workspace</h2>
-      <p class="empty-copy">Create an HBDS element or seed a sample model to begin editing the layout.</p>
-      <div class="empty-actions">
-        <button id="empty-add-hyperclass-button" type="button" class="primary">Hyperclass</button>
-        <button id="empty-seed-demo-button" type="button">Seed Sample</button>
-      </div>
-    </section>
+    <div id="canvas-model-title" aria-live="polite"></div>
   </main>
 
   <div id="model-overview" aria-label="Model overview">
@@ -614,7 +592,6 @@
     <header class="panel-header">
       <div class="eyebrow">HBDS Lab</div>
       <h1>Dynamic Layout Test</h1>
-      <p class="panel-subtitle">Build, link, validate, and reshape HBDS models in one live workspace.</p>
     </header>
 
     <div class="stats-grid" aria-label="Model statistics">
@@ -628,15 +605,11 @@
 
     <section class="control-group">
       <div class="section-title">Model</div>
-      <label for="test-model-select">HBDS Model</label>
+      <label for="test-model-select">Select a HBDS Model</label>
       <select id="test-model-select">
         <option value="">Blank workspace</option>
       </select>
       <div id="model-summary" class="section-meta">Blank workspace</div>
-      <div class="control-row">
-        <button id="load-model-button" type="button">Load</button>
-        <button id="seed-demo-button" type="button">Seed Sample</button>
-      </div>
       <button id="run-scenario-suite-button" type="button" class="quiet">Run Scenario Suite</button>
     </section>
 


### PR DESCRIPTION
### Motivation
- Improve first-run UX by collapsing all menu sections except the `Model` section so users see a focused model selector immediately.
- Remove the distracting empty workspace overlay and show a compact, bold model title on the canvas when a model is loaded.
- Simplify the Model controls by removing redundant `Load`/`Seed Sample` buttons and make model selection load immediately.
- Soften menu colors and default new/blank models to a sensible layout (`grid`) for a friendlier visual and behavior baseline.

### Description
- HTML: removed the `#canvas-empty-state` overlay, added a `#canvas-model-title` element that is shown when `body` has the `has-model` class, removed the header subtitle, changed the `Model` label to `Select a HBDS Model`, and removed the `Load` and `Seed Sample` buttons from the Model section in `test_dynamic_hbds_layout.html`.
- CSS: applied subtler background/panel colors and tighter header spacing, and added styling for `#canvas-model-title` so the loaded model name appears bold and compact at the top of the canvas.
- JS: updated `compactControlSections()` to only auto-open the `Model` section; removed UI bindings and control toggles for the deleted `empty-*`, `seed-demo-button`, and `load-model-button` controls; added `updateCanvasTitle()` and wired it into `updateInterface()` to render the model name on the canvas; and enforced `grid` as the default layout algorithm on init and when resetting via `applyModelLayoutSettings()` and `setLayoutSettings()` in `js/test_dynamic_hbds_layout.js`.

### Testing
- Verified the presence of the updated file with `rg --files | rg 'test_dynamic_hbds_layout\.html'` and inspected changes with targeted `rg -n` searches for patterns such as `load-model-button`, `seed-demo-button`, `test-model-select`, and `canvas-empty-state`, which returned expected results (no remaining references to removed controls).
- Inspected the modified files with `sed -n` and `rg -n` to confirm `compactControlSections()` behavior change and that `updateCanvasTitle()` is called from `updateInterface()`; these checks succeeded.
- Confirmed `layout` defaulting code paths run on startup and on reset by reviewing the added `applyModelLayoutSettings({ algorithm: 'grid' })` and `setLayoutSettings(...)` invocations; review checks succeeded.
- All automated search/inspection checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f4449f2d88331a9501ba67a3ff478)